### PR TITLE
bugfix: renew can be set even if no cache configured

### DIFF
--- a/omniduct/caches/base.py
+++ b/omniduct/caches/base.py
@@ -28,13 +28,13 @@ def cached_method(id_str,
 
         _cache = cache(self)
         _use_cache = use_cache(self, kwargs)
+        _renew = renew(self, kwargs)
 
         if _cache is None or not _use_cache:
             return method(self, **kwargs)
 
         _id_duct = id_duct(self, kwargs)
         _id_str = id_str(self, kwargs)
-        _renew = renew(self, kwargs)
 
         if _renew or not _cache.has_key(_id_duct, _id_str):  # noqa: has_key is not of a dictionary here
             value = method(self, **kwargs)


### PR DESCRIPTION
@matthewwardrop this fixes a bug where if renew is passed in and no cache is configured, renew is passed to _execute