### PR TITLE
add autocomplete to config

### DIFF
--- a/omniduct/utils/config.py
+++ b/omniduct/utils/config.py
@@ -111,6 +111,9 @@ class Configuration(ConfigurationRegistry):
         self._config = {}
         self.__config_path = kwargs.pop('config_path', None)
 
+    def __dir__(self):
+        return sorted(self._register.keys())
+
     @property
     def _config_path(self):
         return self.__config_path


### PR DESCRIPTION
@matthewwardrop 

Add `__dir__` method so that we can TAB-complete config objects

![image](https://cloud.githubusercontent.com/assets/616139/25299262/e96ffa22-26b1-11e7-8308-d4009cb18680.png)
