### PR TITLE
Improve the database api.

### DIFF
--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -13,18 +13,14 @@ import sqlparse
 from decorator import decorator
 from jinja2 import Template
 
+from . import cursor_formatters
 from omniduct.caches.base import cached_method
 from omniduct.duct import Duct
 from omniduct.utils.config import config
 from omniduct.utils.debug import logger, logging_scope
-from omniduct.utils.magics import MagicsProvider, process_line_arguments
+from omniduct.utils.magics import MagicsProvider, process_line_arguments, process_line_cell_arguments
 
 logging.getLogger('requests').setLevel(logging.WARNING)
-
-
-config.register('date_fields',
-                description='Default date fields to attempt to parse when databases',
-                type=list)
 
 
 @decorator
@@ -46,6 +42,13 @@ class DatabaseClient(Duct, MagicsProvider):
 
     DUCT_TYPE = Duct.Type.DATABASE
     DEFAULT_PORT = None
+    CURSOR_FORMATTERS = {
+        'pandas': cursor_formatters.PandasCursorFormatter,
+        'hive': cursor_formatters.HiveCursorFormatter,
+        'csv': cursor_formatters.CsvCursorFormatter,
+        'tuple': cursor_formatters.TupleCursorFormatter,
+        'dict': cursor_formatters.DictCursorFormatter
+    }
 
     def __init__(self, *args, **kwargs):
         '''
@@ -54,6 +57,11 @@ class DatabaseClient(Duct, MagicsProvider):
         to instantiate themselves with arbitrary parameters.
         '''
         Duct.__init_with_kwargs__(self, kwargs, port=self.DEFAULT_PORT)
+
+        self._templates = {}
+        self._sqlalchemy_engine = None
+        self._sqlalchemy_metadata = None
+
         self._init(*args, **kwargs)
 
     @abstractmethod
@@ -61,7 +69,7 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def __call__(self, query, **kwargs):
-        """Calls run() largely for backwards compatibility"""
+        """Calls DatabaseClient.query() largely for backwards compatibility"""
         return self.query(query, **kwargs)
 
     # Querying
@@ -87,108 +95,85 @@ class DatabaseClient(Duct, MagicsProvider):
             statement = statement.encode('utf8')
         return hashlib.sha256(statement).hexdigest()
 
-    @logging_scope("Query", timed=True)
     @sanitize_sqlalchemy_statement
-    @cached_method(
-        id_str=lambda self, kwargs: self.statement_hash(kwargs['statement']),
-        use_cache=lambda self, kwargs: kwargs.pop('use_cache', True) and kwargs.get('query', False) and kwargs.get('parse', True)
-    )
-    def execute(self, statement, query=False, parse=True, index_field=None, date_fields=None,
-                cleanup_statement=True, render_only=False, **kwargs):
+    def execute(self, statement, cleanup=True, async=False, template=False,
+                template_context=None, cursor=None, **kwargs):
         '''
         Execute a statement against the data source.
 
         Parameters
         ----------
         statement : The statement to be executed by the query client.
-        query : Whether this statement should return data, in which case `query` should be `True`;
-            and `False` otherwise.
-        parse : Whether the results of this query should be converted to a pandas DataFrame.
-        index_field : The field to use as an index in the dataframe, or None.
-        date_fields: List of fields to be converted to datetime objects, or None.
+        cleanup : Whether statement should be normalised (whitespace and comments removed).
+                  This helps to avoid missing the cache for similar queries.
+        async : Whether the cursor should be returned before the server-side query
+                computation is complete.
+        template : Whether the statement should be treated as a Jinja2 template.
+        template_context : If the statement is to be treated as a template,
+                 substitute in the parameters using this context.
+        cursor : Rather than creating a new cursor, execute this statement against
+                 the existing provided cursor (or pass None)
         kwargs : Extra keyword arguments to be passed on to _execute, as implemented by subclasses.
 
         Returns
         -------
-        A pandas.DataFrame object if `query` and `parse` are both `True`.
-        A DBAPI2 cursor object if `query` is `True`, and `parse` is `False`.
-        `None` otherwise.
+        A DBAPI2 compatible cursor instance.
         '''
+
         self.connect()
+
+        if template:
+            statement = self.render_template(statement, template_context, by_name=False)
+
         statements = self.statements_split(statement)
-        statements = [self.statement_cleanup(stmt) if cleanup_statement else stmt for stmt in statements]
+        statements = [self.statement_cleanup(stmt) if cleanup else stmt for stmt in statements]
         assert len(statements) > 0, "No non-empty statements were provided."
-        if render_only:
-            return ';\n'.join(statements)
-        cursor = None
+
         for statement in statements[:-1]:
-            cursor = self.connect()._execute(statement, query=False, cursor=cursor, **kwargs)
-        cursor = self.connect()._execute(statements[-1], query, cursor=cursor, **kwargs)
+            cursor = self.connect()._execute(statement, cursor=cursor, async=False, **kwargs)
+        cursor = self.connect()._execute(statements[-1], cursor=cursor, async=async, **kwargs)
 
-        if not query or self._cursor_empty(cursor):
-            return None
-        if parse:
-            df = self._cursor_to_dataframe(cursor)
-            cursor.close()
+        return cursor
 
-            if date_fields is None:  # if user supplied, use as is
-                date_fields = config.date_fields or []
-                date_fields = [field for field in date_fields if field in df]
-
-            if date_fields:
-                try:
-                    df = pandas.io.sql._parse_date_columns(df, date_fields)
-                except:
-                    logger.error('Unable to parse date columns. Perhaps your version of pandas is outdated.')
-            if index_field is not None:
-                df.set_index(index_field, inplace=True)
-            return df
-        else:
-            return cursor
-
-    def query(self, query, **kwargs):
+    @logging_scope("Query", timed=True)
+    @cached_method(
+        id_str=lambda self, kwargs: "{}:\n{}".format(kwargs['format'], self.statement_hash(kwargs['statement'])),
+    )
+    def query(self, statement, format='pandas', format_opts={}, **kwargs):
         '''
-        This method  is shorthand for:
-        >>> client.execute(query, query=True, **kwargs)
+        This method runs the provided statement using `DatabaseClient.execute`,
+        and then formats the results using the nominated formatter.
         '''
-        return self.execute(query, query=True, **kwargs)
 
-    def query_dump(self, query, file, format='hive', **kwargs):
-        '''
-        This method executes a query, and streams the results into a file. This is
-        especially useful for large queries, which may not fit entirely in memory.
-        Currently all fields are treated as strings.
+        cursor = self.execute(statement, async=False, **kwargs)
+        formatter = self._get_formatter(format, cursor, **format_opts)
+        return formatter.dump()
 
-        Parameters
-        ----------
-        query : The query to be executed on the data source.
-        file : A file-like object with a `write` method that accepts strings; or
-            a string representing a path to be written to.
-        format : A string indicating the format of the outputted data.
-            Valid options are 'hive' and 'csv'.
-        kwargs : Additional keyword arguments passed on to `self.execute`.
+    def stream(self, statement, format='dict', format_opts={}, batch=None, **kwargs):
 
-        Returns
-        -------
-        An integer representing the number of output records.
-        '''
-        cursor = self.execute(query, parse=False, **kwargs)
-        record = cursor.fetchone()
-        if format == 'hive':
-            sep = "\t"
-            pre = ''
-            post = '\n'
-        else:
-            sep = '","'
-            pre = '"'
-            post = '"\n'
-        if isinstance(file, six.string_types):
-            file = open(file, 'w')
-        while record is not None:
-            file.write(pre + sep.join([str(v).replace('"', '\"') for v in record]) + post)
-            record = cursor.fetchone()
-        file.close()
-        cursor.close()
+        cursor = self.execute(statement, async=False, **kwargs)
+        formatter = self._get_formatter(format, cursor, **format_opts)
+
+        for row in formatter.stream(batch=batch):
+            yield row
+
+    def _get_formatter(self, format, cursor, **kwargs):
+        assert isinstance(format, cursor_formatters.CursorFormatter) or format in self.CURSOR_FORMATTERS, "Invalid format '{}'. Choose from: {}".format(format, ','.join(self.CURSOR_FORMATTERS.keys()))
+        formatter = self.CURSOR_FORMATTERS[format]
+        return formatter(cursor, **kwargs)
+
+    def stream_to_file(self, statement, file, format='csv', **kwargs):
+        close_later = False
+        if isinstance(file, str):
+            file = open(str, 'w')
+            close_later = True
+
+        try:
+            for row in self.stream(statement, format=format, **kwargs):
+                file.writeline(str(row))
+        finally:
+            if close_later:
+                file.close()
 
     def execute_from_file(self, file, **kwargs):
         """
@@ -202,19 +187,58 @@ class DatabaseClient(Duct, MagicsProvider):
             Extra parameters to pass on to `execute`.
         """
         with open(file, 'r') as f:
-            query = f.read()
-        return self.query(query, **kwargs)
+            return self.execute(f.read(), **kwargs)
 
     def query_from_file(self, file, **kwargs):
         '''
         This method is shorthand for:
         QueryClient.execute_from_file(file, parse=True, **kwargs)
         '''
-        return self.execute_file(file, parse=True, **kwargs)
+        with open(file, 'r') as f:
+            return self.query(f.read(), **kwargs)
+
+    def add_template(self, name, body):
+        self._templates[name] = body
+        return self
+
+    def render_template(self, name_or_statement, context=None, by_name=False):
+
+        if by_name:
+            if name_or_statement not in self._templates:
+                raise ValueError("No such template of name: '{}'.".format(name_or_statement))
+            statement = self._templates[name_or_statement]
+        else:
+            statement = name_or_statement
+
+        if not context:
+            context = {}
+
+        # Substitute in any other named statements recursively
+        while '{{{' in statement or '{{%' in statement:
+            statement = Template(statement,
+                                 block_start_string='{{%',
+                                 block_end_string='%}}',
+                                 variable_start_string='{{{',
+                                 variable_end_string='}}}',
+                                 comment_start_string='{{#',
+                                 comment_end_string='#}}').render(getattr(self, '_templates', {}))
+
+        # Evaluate final template in provided context
+        statement = Template(statement).render(context)
+
+        return statement
+
+    def execute_from_template(self, name, context=None, **kwargs):
+        statement = self.render_template(name, context, by_name=True)
+        return self.execute(statement, **kwargs)
+
+    def query_from_template(self, name, context=None, **kwargs):
+        statement = self.render_template(name, context, by_name=True)
+        return self.query(statement, **kwargs)
 
     # Uploading data to data store
-
-    def push(self, df, table, overwrite=False, **kwargs):
+    @logging_scope('Push', timed=True)
+    def push(self, df, table, if_exists='fail', **kwargs):
         '''
         This method pushes a local dataframe `df` to the connected data store
         as a table `table`.
@@ -230,26 +254,25 @@ class DatabaseClient(Duct, MagicsProvider):
         kwargs : dict
             Additional arguments which are passed on to `QueryClient._push`.
         '''
-        self._push(df, table, overwrite=overwrite, **kwargs)
-
-    @abstractmethod
-    def _push(self, df, table, overwrite=True, **kwargs):
-        pass
+        assert if_exists in {'fail', 'replace', 'append'}
+        self.connect()._push(df, table, if_exists=if_exists, **kwargs)
 
     # Table properties
 
     @abstractmethod
-    def _execute(self, statement, query=True, cursor=None, **kwargs):
+    def _execute(self, statement, cursor=None, async=False, **kwargs):
         pass
 
-    @abstractmethod
+    def _push(self, df, table, if_exists='fail', **kwargs):
+        if self._sqlalchemy_engine is None:
+            raise NotImplementedError("Support for pushing data tables using `{}` is not currently implemented.".format(self.__class__.__name__))
+        return df.to_sql(name=table, con=self._sqlalchemy_engine, index=False, if_exists=if_exists, **kwargs)
+
     def _cursor_empty(self, cursor):
         pass
 
-    def _cursor_to_dataframe(self, cursor):
-        records = cursor.fetchall()
-        description = cursor.description
-        return pd.DataFrame(data=records, columns=[c[0] for c in description])
+    def _cursor_wait(self, cursor, poll_interval=1):
+        pass
 
     def table_list(self, **kwargs):
         '''
@@ -309,50 +332,43 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def _register_magics(self, base_name):
-        from IPython.core.magic import register_line_magic, register_cell_magic
+        from IPython.core.magic import register_line_magic, register_cell_magic, register_line_cell_magic
 
-        @register_cell_magic(base_name)
-        @process_line_arguments
-        def query_magic(statement, variable=None, show='head', template=True, name=None, auto_transpose=True, **kwargs):
+        def statement_executor_magic(executor, statement, variable=None, show='head', auto_transpose=True, template=True, template_context=None, **kwargs):
 
             ip = get_ipython()
 
-            # If name is specified, save this query as a template that can be used in subsequent queries
-            if name is not None:
-                if not hasattr(self, '_templates'):
-                    self._templates = {}
-                self._templates[name] = statement
+            if template_context is None:
+                template_context = ip.user_ns
 
-            # Create the query by inserting stored templates where indicated by `::<name>::`
-            # And then render the template using variables in the current user namespace.
-            if template:
-                statement = Template(statement,
-                                     block_start_string='#{%#',
-                                     block_end_string='#%}#',
-                                     variable_start_string='::',
-                                     variable_end_string='::',
-                                     comment_start_string='#{%#',
-                                     comment_end_string='#%}#').render(getattr(self, '_templates', {}))
-                statement = Template(statement).render(ip.user_ns)
+            # Line magic
+            if statement is None:
+                return self.query_from_template(variable, context=template_context, by_name=True)
 
-            result = self(statement, **kwargs)
+            # Cell magic
+            result = getattr(self, executor)(statement, template=template, template_context=template_context, **kwargs)
 
             if variable is not None:
                 ip.user_ns[variable] = result
 
-            if kwargs.get('render_only', False):
-                print(result, file=sys.stderr)
+            if executor != 'query':
+                if variable is None:
+                    return result
                 return
             elif variable is None:
                 return result
 
+            format = kwargs.get('format', 'pandas')
+            if show == 'head':
+                show = 10
             if isinstance(show, int):
-                r = result.head(show)
-                if show <= 10:
-                    r = r.T
-                return r
-            elif show == 'head':
-                r = result.head()
+                if format == 'pandas':
+                    r = result.head(show)
+                    if show <= 10:
+                        r = r.T
+                    return r
+                else:
+                    return result[:show]
             elif show == 'all':
                 r = result
             elif show == 'none':
@@ -360,9 +376,49 @@ class DatabaseClient(Duct, MagicsProvider):
             else:
                 raise ValueError("Omniduct does not recognise the argument show='{0}' in cell magic.".format(show))
 
-            if auto_transpose and len(r) <= 10:
+            if format == 'pandas' and auto_transpose and len(r) <= 10:
                 return r.T
             return r
+
+        @register_line_cell_magic(base_name)
+        @process_line_cell_arguments
+        def query_magic(*args, **kwargs):
+            return statement_executor_magic('query', *args, **kwargs)
+
+        @register_line_cell_magic("{}.{}".format(base_name, 'execute'))
+        @process_line_cell_arguments
+        def query_magic(*args, **kwargs):
+            return statement_executor_magic('execute', *args, **kwargs)
+
+        @register_line_cell_magic("{}.{}".format(base_name, 'stream'))
+        @process_line_cell_arguments
+        def query_magic(*args, **kwargs):
+            return statement_executor_magic('stream', *args, **kwargs)
+
+        @register_cell_magic("{}.{}".format(base_name, 'template'))
+        @process_line_arguments
+        def add_template(body, name):
+            self.add_template(name, body)
+
+        @register_line_cell_magic("{}.{}".format(base_name, 'render'))
+        @process_line_cell_arguments
+        def render_template(body=None, name=None, context=None, show=True):
+
+            ip = get_ipython()
+
+            try:
+                if body is None:
+                    assert name is not None, "Name must be specified in line-mode."
+                    rendered = self.render_template(name, context=context or ip.user_ns, by_name=True)
+                    if not show:
+                        return rendered
+                else:
+                    rendered = self.render_template(body, context=context or ip.user_ns, by_name=False)
+                    if name is not None:
+                        ip.user_ns[name] = rendered
+            finally:
+                if show:
+                    print(rendered)
 
         @register_line_magic("{}.{}".format(base_name, 'desc'))
         @process_line_arguments
@@ -371,10 +427,10 @@ class DatabaseClient(Duct, MagicsProvider):
 
         @register_line_magic("{}.{}".format(base_name, 'head'))
         @process_line_arguments
-        def table_desc(table_name, **kwargs):
+        def table_head(table_name, **kwargs):
             return self.table_head(table_name, **kwargs)
 
         @register_line_magic("{}.{}".format(base_name, 'props'))
         @process_line_arguments
-        def table_desc(table_name, **kwargs):
+        def table_props(table_name, **kwargs):
             return self.table_props(table_name, **kwargs)

--- a/omniduct/databases/cursor_formatters.py
+++ b/omniduct/databases/cursor_formatters.py
@@ -1,0 +1,146 @@
+import csv
+import io
+
+
+class CursorFormatter(object):
+
+    def __init__(self, cursor, **kwargs):
+        self.cursor = cursor
+        self.init(**kwargs)
+
+    def init(self):
+        pass
+
+    @property
+    def column_names(self):
+        return [c[0] for c in self.cursor.description]
+
+    @property
+    def column_formats(self):
+        return [c[1] for c in self.cursor.description]
+
+    def dump(self):
+        try:
+            data = self.cursor.fetchall()
+            out = self.format_dump(data)
+        finally:
+            self.cursor.close()
+        return out
+
+    def stream(self, batch=None):
+        try:
+            column_names = self.column_names
+            column_formats = self.column_formats
+
+            if batch is not None:
+                while True:
+                    b = self.cursor.fetchmany(batch)
+                    if len(b) == 0:
+                        return
+                    yield self.format_dump(b)
+            else:
+                for row in self.cursor:
+                    yield self.format_row(row)
+        finally:
+            self.cursor.close()
+
+    def format_dump(self, data):
+        raise NotImplementedError("{} does not support formatting dumped data.".format(self.__class__.__name__))
+
+    def format_row(self, row):
+        raise NotImplementedError("{} does not support formatting streaming data.".format(self.__class__.__name__))
+
+
+class PandasCursorFormatter(CursorFormatter):
+
+    def init(self, index_fields=None, date_fields=None):
+        self.index_fields = index_fields
+        self.date_fields = date_fields
+
+    def format_dump(self, data):
+        import pandas as pd
+
+        df = pd.DataFrame(data=data, columns=self.column_names)
+
+        if self.date_fields is not None:
+            try:
+                df = pandas.io.sql._parse_date_columns(df, self.date_fields)
+            except Exception as e:
+                logger.warning('Unable to parse date columns. Perhaps your version of pandas is outdated.'
+                               'Original error message was: {}: {}'.format(e.__class__.__name__, str(e)))
+
+        if self.index_fields is not None:
+            df.set_index(self.index_fields, inplace=True)
+
+        return df
+
+    def format_row(self, row):
+        import pandas as pd
+
+        # TODO: Handle parsing of date fields
+
+        return pd.Series(row, index=self.column_names)
+
+
+class DictCursorFormatter(CursorFormatter):
+
+    def format_dump(self, data):
+        return [self.format_row(row) for row in data]
+
+    def format_row(self, row):
+        return dict(zip(self.column_names, row))
+
+
+class TupleCursorFormatter(CursorFormatter):
+
+    def format_dump(self, data):
+        return [self.format_row(row) for row in self.data]
+
+    def format_row(self, row):
+        return row
+
+
+class CsvCursorFormatter(CursorFormatter):
+
+    # TODO: Add support for outputting headers
+
+    FORMAT_PARAMS = {
+        'delimiter': ',',
+        'doublequote': False,
+        'escapechar': '\\',
+        'lineterminator': '\r\n',
+        'quotechar': '"',
+        'quoting': csv.QUOTE_MINIMAL
+    }
+
+    def init(self):
+        self.output = io.StringIO()
+        self.writer = csv.writer(self.output, **self.FORMAT_PARAMS)
+
+    def format_dump(self, data):
+        try:
+            self.writer.writerows(data)
+            return self.output.getvalue()
+        finally:
+            self.output.truncate(0)
+
+    def format_row(self, row):
+        try:
+            self.writer.writerow(row)
+            return self.output.getvalue()
+        finally:
+            self.output.truncate(0)
+
+
+class HiveCursorFormatter(CsvCursorFormatter):
+
+    # TODO: Handle NULL -> \0
+
+    FORMAT_PARAMS = {
+        'delimiter': '\t',
+        'doublequote': False,
+        'escapechar': None,
+        'lineterminator': '\n',
+        'quotechar': '',
+        'quoting': csv.QUOTE_NONE
+    }

--- a/omniduct/utils/debug.py
+++ b/omniduct/utils/debug.py
@@ -202,7 +202,10 @@ class LoggingHandler(logging.Handler):
         return "{}".format(record.getMessage())
 
     def handle(self, record):
-        scopes = logger.current_scopes
+        try:
+            scopes = logger.current_scopes
+        except:
+            scopes = []
 
         if config.logging_level < logging.INFO:  # Print everything verbosely
             prefix = '\t' * len(scopes)

--- a/omniduct/utils/dependencies.py
+++ b/omniduct/utils/dependencies.py
@@ -1,6 +1,10 @@
+import re
+
 import pkg_resources
+from pkg_resources import VersionConflict
 
 from omniduct._version import __optional_dependencies__
+from omniduct.utils.debug import logger
 
 
 def check_dependencies(protocols, message=None):
@@ -8,11 +12,23 @@ def check_dependencies(protocols, message=None):
     for protocol in protocols:
         dependencies.extend(__optional_dependencies__.get(protocol, []))
     missing_deps = []
+    warning_deps = {}
     for dep in dependencies:
         try:
             pkg_resources.get_distribution(dep)
+        except VersionConflict:
+            m = re.match('^[a-z_][a-z0-9]*', dep)
+            if m:
+                warning_deps[dep] = "{}=={}".format(m.group(0), pkg_resources.get_distribution(m.group(0)).version)
+            else:
+                logger.warning("Could not find distribution for '{}'.".format(m.group(0)))
         except:
             missing_deps.append(dep)
+    if warning_deps:
+        message = "You may have some outdated packages:\n"
+        for key in sorted(warning_deps):
+            message += '\t- Want {}, found {}'.format(key, warning_deps[key])
+        logger.warning(message)
     if missing_deps:
         message = message or "Whoops! You do not seem to have all the dependencies required."
         fix = ("You can fix this by running:\n\n"

--- a/omniduct/utils/magics.py
+++ b/omniduct/utils/magics.py
@@ -14,6 +14,18 @@ def process_line_arguments(f):
     return wrapped
 
 
+def process_line_cell_arguments(f):
+    def wrapped(*args, **kwargs):
+        args = list(args)
+        new_args, new_kwargs = _process_line_arguments(args.pop(0))
+        if len(args) == 0:
+            args += [None]
+        args += new_args
+        kwargs.update(new_kwargs)
+        return f(*args, **kwargs)
+    return wrapped
+
+
 def _process_line_arguments(line_arguments):
     args = []
     kwargs = {}
@@ -28,7 +40,7 @@ def _process_line_arguments(line_arguments):
             kwargs[key] = value
         else:
             if reached_kwargs:
-                raise ValueError('Positional argument `{}` after keyword argment.'.format(arg))
+                raise ValueError('Positional argument `{}` after keyword argument.'.format(arg))
             args.append(arg)
     return args, kwargs
 


### PR DESCRIPTION
This PR lands some improvements to the database API. It does the following:
- Clarifies pandas conversion (only the `query` method returns formatted dumps from cursors like pandas dataframes, `execute` always returns a cursor)
- Adds support for streaming data from the cursor using `stream`, which supports the same formats as `query`
- Adds notion of a `CursorFormatter`
- Greatly improved handling of templates throughout
- Fixes `query_from_file` and `execute_from_file`.
- Renames `query_dump` to `stream_to_file`, which now wraps around the aforementioned `stream`
- Adds support for pushing dataframes using hive/presto via sqlalchemy (with upstream patch to PyHive)
- Minor improvements to logging and dependency handling.