### PR TITLE
add timer to presto

### DIFF
--- a/omniduct/utils/debug.py
+++ b/omniduct/utils/debug.py
@@ -118,7 +118,7 @@ class StatusLogger(object):
                 prefix = ": ".join(self.current_scopes) + ": "
             else:
                 prefix = "\t" * len(self.current_scopes)
-            self._progress_bar = progressbar.ProgressBar(widgets=[prefix, progressbar.widgets.Bar(), progressbar.widgets.Timer()],
+            self._progress_bar = progressbar.ProgressBar(widgets=[prefix, progressbar.widgets.Bar(), progressbar.widgets.Timer(format=' %(elapsed)s')],
                                                          redirect_stderr=True,
                                                          redirect_stdout=True).start()
 

--- a/omniduct/utils/debug.py
+++ b/omniduct/utils/debug.py
@@ -118,7 +118,7 @@ class StatusLogger(object):
                 prefix = ": ".join(self.current_scopes) + ": "
             else:
                 prefix = "\t" * len(self.current_scopes)
-            self._progress_bar = progressbar.ProgressBar(widgets=[prefix, progressbar.widgets.Bar()],
+            self._progress_bar = progressbar.ProgressBar(widgets=[prefix, progressbar.widgets.Bar(), progressbar.widgets.Timer()],
                                                          redirect_stderr=True,
                                                          redirect_stdout=True).start()
 


### PR DESCRIPTION
@matthewwardrop 

User sanity feature: keep the clock ticking so that even if computation isn't progressing, we know that polling is still occuring. 

![image](https://user-images.githubusercontent.com/616139/29194015-9558c306-7ddc-11e7-9347-a689c2f914ac.png)
