### PR TITLE
Add a RESTful client

### DIFF
--- a/omniduct/duct.py
+++ b/omniduct/duct.py
@@ -44,6 +44,8 @@ class Duct(with_metaclass(ProtocolRegisteringABCMeta, object)):
         FILESYSTEM = 'filesystems'
         DATABASE = 'databases'
         CACHE = 'caches'
+        RESTFUL = 'rest_clients'
+        OTHER = 'other'
 
     AUTO_LOGGING_SCOPE = True
     DUCT_TYPE = None

--- a/omniduct/protocols.py
+++ b/omniduct/protocols.py
@@ -5,5 +5,6 @@ from .databases.sqlalchemy import SQLAlchemyClient
 from .filesystems.local import LocalFsClient
 from .filesystems.webhdfs import WebHdfsClient
 from .remotes.ssh import SSHClient
+from .restful.rest import BasicRestClient
 
 # from .remotes.ssh_paramiko import ParamikoSSHClient  # Not yet ready for prime time

--- a/omniduct/protocols.py
+++ b/omniduct/protocols.py
@@ -5,6 +5,6 @@ from .databases.sqlalchemy import SQLAlchemyClient
 from .filesystems.local import LocalFsClient
 from .filesystems.webhdfs import WebHdfsClient
 from .remotes.ssh import SSHClient
-from .restful.rest import BasicRestClient
+from .restful.base import RestClient
 
 # from .remotes.ssh_paramiko import ParamikoSSHClient  # Not yet ready for prime time

--- a/omniduct/restful/base.py
+++ b/omniduct/restful/base.py
@@ -1,8 +1,11 @@
+import requests
+from future.moves.urllib.parse import urlparse, urlencode, urljoin
+
 from omniduct.duct import Duct
 from omniduct.utils.magics import MagicsProvider, process_line_arguments
 
 
-class RestClient(Duct):
+class RestClientBase(Duct):
     '''
     This is a simple wrapper around the requests library to simplify the use
     of RESTful clients with omniduct. This allows all the automatic features
@@ -12,25 +15,42 @@ class RestClient(Duct):
     to access various endpoints.
     '''
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args, server_protocol='http', assume_json=False, endpoint_prefix='', **kwargs):
         '''
         This is a shim __init__ function that passes all arguments onto
         `self._init`, which is implemented by subclasses. This allows subclasses
         to instantiate themselves with arbitrary parameters.
         '''
-        Duct.__init_with_kwargs__(self, kwargs)
+        Duct.__init_with_kwargs__(self, kwargs, port=80)
+
+        self.server_protocol = server_protocol
+        self.assume_json = assume_json
+        self.endpoint_prefix = endpoint_prefix
+
         self._init(*args, **kwargs)
 
-    def _init(self, base_url):
-        self.base_url = base_url
+    def _init(self):
+        pass
 
-    def request(self, method, endpoint, **kwargs):
+    def __call__(self, endpoint, method='get', **kwargs):
+        if self.assume_json:
+            return self.request_json(endpoint, method=method, **kwargs)
+        return self.request(endpoint, method=method, **kwargs)
+
+    @property
+    def base_url(self):
+        url = urljoin('{}://{}:{}'.format(self.server_protocol, self.host, self.port or 80), self.endpoint_prefix)
+        if not url.endswith('/'):
+            url += '/'
+        return url
+
+    def request(self, endpoint, method='get', **kwargs):
         self.connect()
         url = urljoin(self.base_url, endpoint)
         return requests.request(method, url, **kwargs)
 
-    def request_json(self, method, endpoint, **kwargs):
-        request = self.request(method, endpoint, **kwargs)
+    def request_json(self, endpoint, method='get', **kwargs):
+        request = self.request(endpoint, method=method, **kwargs)
         if not request.status_code == 200:
             raise RuntimeError("Server responded with HTTP response code {}, with content: {}.".format(request.status_code, request.content.decode()))
         return request.json()
@@ -44,6 +64,5 @@ class RestClient(Duct):
     def _disconnect(self):
         pass
 
-
-class BasicRestClient(RestClient):
+class RestClient(RestClientBase):
     PROTOCOLS = ['rest']

--- a/omniduct/restful/base.py
+++ b/omniduct/restful/base.py
@@ -15,6 +15,8 @@ class RestClientBase(Duct):
     to access various endpoints.
     '''
 
+    DUCT_TYPE = Duct.Type.RESTFUL
+
     def __init__(self, *args, server_protocol='http', assume_json=False, endpoint_prefix='', **kwargs):
         '''
         This is a shim __init__ function that passes all arguments onto
@@ -63,6 +65,7 @@ class RestClientBase(Duct):
 
     def _disconnect(self):
         pass
+
 
 class RestClient(RestClientBase):
     PROTOCOLS = ['rest']

--- a/omniduct/restful/base.py
+++ b/omniduct/restful/base.py
@@ -1,0 +1,49 @@
+from omniduct.duct import Duct
+from omniduct.utils.magics import MagicsProvider, process_line_arguments
+
+
+class RestClient(Duct):
+    '''
+    This is a simple wrapper around the requests library to simplify the use
+    of RESTful clients with omniduct. This allows all the automatic features
+    around port forwarding from remote hosts to be inherited. This client can
+    be used directly, or decorated by subclasses which can add methods
+    specific to any REST service; and internally use `request` and `request_json`
+    to access various endpoints.
+    '''
+
+    def __init__(self, *args, **kwargs):
+        '''
+        This is a shim __init__ function that passes all arguments onto
+        `self._init`, which is implemented by subclasses. This allows subclasses
+        to instantiate themselves with arbitrary parameters.
+        '''
+        Duct.__init_with_kwargs__(self, kwargs)
+        self._init(*args, **kwargs)
+
+    def _init(self, base_url):
+        self.base_url = base_url
+
+    def request(self, method, endpoint, **kwargs):
+        self.connect()
+        url = urljoin(self.base_url, endpoint)
+        return requests.request(method, url, **kwargs)
+
+    def request_json(self, method, endpoint, **kwargs):
+        request = self.request(method, endpoint, **kwargs)
+        if not request.status_code == 200:
+            raise RuntimeError("Server responded with HTTP response code {}, with content: {}.".format(request.status_code, request.content.decode()))
+        return request.json()
+
+    def _connect(self):
+        pass
+
+    def _is_connected(self):
+        return True
+
+    def _disconnect(self):
+        pass
+
+
+class BasicRestClient(RestClient):
+    PROTOCOLS = ['rest']


### PR DESCRIPTION
REST clients are very simple to write, since it simply involves querying against a remote url. This PR nevertheless adds a simple wrapper around the `requests` library so that we can take advantage of the standard `Duct` routing and port-forwarding capabilities.

`RestClient` can be subclassed to provide more powerful/customised REST clients.