### PR TITLE
Don't fail if some ducts in config can't be created

### DIFF
--- a/omniduct/duct.py
+++ b/omniduct/duct.py
@@ -11,7 +11,7 @@ from enum import Enum
 import six
 from future.utils import raise_with_traceback, with_metaclass
 
-from omniduct.errors import DuctConnectionError, DuctServerUnreachable
+from omniduct.errors import DuctServerUnreachable, DuctProtocolUnknown
 from omniduct.utils.debug import logger, logging_scope
 from omniduct.utils.dependencies import check_dependencies
 from omniduct.utils.ports import is_port_bound
@@ -34,6 +34,8 @@ class ProtocolRegisteringABCMeta(ABCMeta):
                     cls._protocols[key] = cls
 
     def _for_protocol(cls, key):
+        if key not in cls._protocols:
+            raise DuctProtocolUnknown("Missing `Duct` implementation for protocol: '{}'.".format(key))
         return cls._protocols[key]
 
 

--- a/omniduct/errors.py
+++ b/omniduct/errors.py
@@ -8,3 +8,7 @@ class DuctConnectionError(RuntimeError):
 
 class DuctServerUnreachable(RuntimeError):
     pass
+
+
+class DuctProtocolUnknown(RuntimeError):
+    pass

--- a/omniduct/registry.py
+++ b/omniduct/registry.py
@@ -4,6 +4,8 @@ import yaml
 from omniduct.duct import Duct
 from omniduct.utils.magics import MagicsProvider
 from omniduct.utils.proxies import NestedDictObjectProxy
+from omniduct.utils.debug import logger
+from omniduct.errors import DuctProtocolUnknown
 
 
 class DuctRegistry(object):
@@ -82,7 +84,10 @@ class DuctRegistry(object):
             for names, options in config.get(t, {}).items():
                 protocol = options.pop('protocol')
                 register_magics = options.pop('register_magics', True)
-                self.new(names, protocol, register_magics=register_magics, **options)
+                try:
+                    self.new(names, protocol, register_magics=register_magics, **options)
+                except DuctProtocolUnknown as e:
+                    logger.error("Failed to configure `Duct` instance(s) '{}'. {}".format("', '".join(names.split(',')), str(e)))
 
         return self
 


### PR DESCRIPTION
@matthewwardrop 

This PR is designed to enable registry initialization when some of the ducts being configured aren't available. This happens during development of a new protocol or when the config is wrong but I don't want my whole env to be taken down. 