### PR TITLE
Replace deprecated module.

### DIFF
--- a/omniduct/duct.py
+++ b/omniduct/duct.py
@@ -74,7 +74,10 @@ class Duct(with_metaclass(ProtocolRegisteringABCMeta, object)):
         self.__disconnecting = False
 
     def __init_with_kwargs__(self, kwargs, **fallbacks):
-        keys = inspect.getfullargspec(Duct.__init__).args[1:]
+        if six.PY3:
+            keys = inspect.getfullargspec(Duct.__init__).args[1:]
+        else:
+            keys = inspect.getargspec(Duct.__init__).args[1:]
         params = {}
         for key in keys:
             if key in kwargs:

--- a/omniduct/duct.py
+++ b/omniduct/duct.py
@@ -74,7 +74,7 @@ class Duct(with_metaclass(ProtocolRegisteringABCMeta, object)):
         self.__disconnecting = False
 
     def __init_with_kwargs__(self, kwargs, **fallbacks):
-        keys = inspect.getargspec(Duct.__init__).args[1:]
+        keys = inspect.getfullargspec(Duct.__init__).args[1:]
         params = {}
         for key in keys:
             if key in kwargs:


### PR DESCRIPTION
This is for replacing deprecated method 'getargspec' to 'getfullargspec'. It does not have difference except about handling keyword-only parameter.
But because I tested on python 3.6, it could cause error on older one.

Could you look on?
