### PR TITLE
Use triple double-quotes for docstrings (PEP 257)

### DIFF
--- a/omniduct/caches/base.py
+++ b/omniduct/caches/base.py
@@ -71,11 +71,11 @@ class Cache(Duct):
     DUCT_TYPE = Duct.Type.CACHE
 
     def __init__(self, *args, **kwargs):
-        '''
+        """
         This is a shim __init__ function that passes all arguments onto
         `self._init`, which is implemented by subclasses. This allows subclasses
         to instantiate themselves with arbitrary parameters.
-        '''
+        """
         Duct.__init_with_kwargs__(self, kwargs)
         self._init(*args, **kwargs)
 

--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -44,10 +44,10 @@ def render_statement(method, self, statement, *args, **kwargs):
 
 
 class DatabaseClient(Duct, MagicsProvider):
-    '''
+    """
     QueryClient is an abstract class that can be subclassed to allow the databases
     of various data sources, such as databases or website apis.
-    '''
+    """
 
     DUCT_TYPE = Duct.Type.DATABASE
     DEFAULT_PORT = None
@@ -63,11 +63,11 @@ class DatabaseClient(Duct, MagicsProvider):
     DEFAULT_CURSOR_FORMATTER = 'pandas'
 
     def __init__(self, *args, **kwargs):
-        '''
+        """
         This is a shim __init__ function that passes all arguments onto
         `self._init`, which is implemented by subclasses. This allows subclasses
         to instantiate themselves with arbitrary parameters.
-        '''
+        """
         Duct.__init_with_kwargs__(self, kwargs, port=self.DEFAULT_PORT)
 
         self._templates = kwargs.pop('templates', {})
@@ -153,7 +153,7 @@ class DatabaseClient(Duct, MagicsProvider):
         deserializer=cache_deserializer
     )
     def query(self, statement, format=None, format_opts={}, **kwargs):
-        '''
+        """
         Execute a statement against the data source using `.execute()`, and then
         collect and return the results in the nominated format; optionally (and
         by default) caching the result.
@@ -168,7 +168,7 @@ class DatabaseClient(Duct, MagicsProvider):
         renew : True or False (default). If cache is being used, renew it before
                 returning stored value.
         **kwargs : Additional arguments to pass on to `.execute()`.
-        '''
+        """
         cursor = self.execute(statement, async=False, template=False, **kwargs)
 
         # Some DBAPI2 cursor implementations error if attempting to extract
@@ -220,10 +220,10 @@ class DatabaseClient(Duct, MagicsProvider):
             return self.execute(f.read(), **kwargs)
 
     def query_from_file(self, file, **kwargs):
-        '''
+        """
         This method is shorthand for:
         QueryClient.execute_from_file(file, parse=True, **kwargs)
-        '''
+        """
         with open(file, 'r') as f:
             return self.query(f.read(), **kwargs)
 
@@ -285,7 +285,7 @@ class DatabaseClient(Duct, MagicsProvider):
     # Uploading data to data store
     @logging_scope('Push', timed=True)
     def push(self, df, table, if_exists='fail', **kwargs):
-        '''
+        """
         This method pushes a local dataframe `df` to the connected data store
         as a table `table`.
 
@@ -301,7 +301,7 @@ class DatabaseClient(Duct, MagicsProvider):
             - append: If table exists, insert data. Create if does not exist.
         kwargs : dict
             Additional arguments which are passed on to `QueryClient._push`.
-        '''
+        """
         assert if_exists in {'fail', 'replace', 'append'}
         self.connect()._push(df, table, if_exists=if_exists, **kwargs)
 
@@ -323,10 +323,10 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def table_list(self, **kwargs):
-        '''
+        """
         Return a list of table names in the data source as a DataFrame. Additional kwargs are
         passed to `QueryClient._table_list`.
-        '''
+        """
         return self._table_list(**kwargs)
 
     @abstractmethod
@@ -334,9 +334,9 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def table_exists(self, table, **kwargs):
-        '''
+        """
         Return boolean if table exists in schema
-        '''
+        """
         return self._table_exists(table=table, **kwargs)
 
     @abstractmethod
@@ -344,12 +344,12 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def table_desc(self, table, **kwargs):
-        '''
+        """
         Describe a table in the data source. Additional kwargs are
         passed to `QueryClient._table_desc`.
 
         Returns a pandas dataframe of table fields and descriptors.
-        '''
+        """
         return self._table_desc(table, **kwargs)
 
     @abstractmethod
@@ -357,12 +357,12 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def table_head(self, table, n=10, **kwargs):
-        '''
+        """
         Show a sample of the data in `table` of the data source. `n` is the number of records
         to show in this sample. The additional `kwargs` are passed on to `QueryClient._table_head`.
 
         Returns a pandas DataFrame.
-        '''
+        """
         return self._table_head(table, n=n, **kwargs)
 
     @abstractmethod
@@ -370,9 +370,9 @@ class DatabaseClient(Duct, MagicsProvider):
         pass
 
     def table_props(self, table, **kwargs):
-        '''
+        """
         Return a dataframe of table properties for `table`.
-        '''
+        """
         return self._table_props(table, **kwargs)
 
     @abstractmethod

--- a/omniduct/filesystems/base.py
+++ b/omniduct/filesystems/base.py
@@ -12,11 +12,11 @@ class FileSystemClient(Duct, MagicsProvider):
     DEFAULT_PORT = None
 
     def __init__(self, *args, **kwargs):
-        '''
+        """
         This is a shim __init__ function that passes all arguments onto
         `self._init`, which is implemented by subclasses. This allows subclasses
         to instantiate themselves with arbitrary parameters.
-        '''
+        """
         Duct.__init_with_kwargs__(self, kwargs, port=self.DEFAULT_PORT)
         self._init(*args, **kwargs)
 
@@ -102,10 +102,10 @@ class FileSystemClient(Duct, MagicsProvider):
     # File transfer
 
     def copy_to_local(self, source, dest=None, overwrite=False):
-        '''
+        """
         Copies a file from `source` on the remote host to `dest` on the local host.
         If `overwrite` is `True`, overwrites file on the local host.
-        '''
+        """
         if dest is None:
             dest = os.path.basename(source)
         if not overwrite and os.path.exists(dest):
@@ -113,10 +113,10 @@ class FileSystemClient(Duct, MagicsProvider):
         return self.connect()._copy_to_local(source, dest, overwrite)
 
     def copy_from_local(self, source, dest=None, overwrite=False):
-        '''
+        """
         Copies a file from `source` on the local host to `dest` on the remote host.
         If `overwrite` is `True`, overwrites file on the remote host.
-        '''
+        """
         if dest is None:
             dest = os.path.basename(source)
         if not overwrite and self.exists(dest):

--- a/omniduct/remotes/base.py
+++ b/omniduct/remotes/base.py
@@ -62,10 +62,10 @@ class PortForwardingRegister(object):
 
 
 class RemoteClient(FileSystemClient):
-    '''
+    """
     SSHClient is an abstract class that can be subclassed into a fully-functional
     SSH client.
-    '''
+    """
 
     DUCT_TYPE = Duct.Type.REMOTE
 
@@ -96,10 +96,10 @@ class RemoteClient(FileSystemClient):
 
     @abstractmethod
     def _init(self, **kwargs):
-        '''
+        """
         To be defined by subclasses, and called immediately after __init__. This allows
         subclasses to initialise themselves.
-        '''
+        """
         pass
 
     # SSH commands
@@ -168,18 +168,18 @@ class RemoteClient(FileSystemClient):
         return True
 
     def execute(self, cmd, **kwargs):
-        '''
+        """
         Execute `cmd` on the remote shell via ssh. Additional keyword arguments are
         passed on to subclasses.
-        '''
+        """
         return self.connect()._execute(cmd, **kwargs)
 
     @abstractmethod
     def _execute(self, cmd, **kwargs):
-        '''
+        """
         Should return a tuple of:
         (<status code>, <data printed to stdout>, <data printed to stderr>)
-        '''
+        """
         raise NotImplementedError
 
     # Port forwarding code
@@ -199,13 +199,13 @@ class RemoteClient(FileSystemClient):
         return host, port, local_port
 
     def port_forward(self, remote_host, remote_port=None, local_port=None):
-        '''
+        """
         Establishes a local port forwarding from local port `local` to remote
         port `remote`. If `local` is `None`, automatically find an available local
         port, and forward it. This method returns the used local port.
 
         If the remote port is already forwarded, a new connection is not created.
-        '''
+        """
 
         # Hostname and port extraction
         remote_host, remote_port, local_port = self.__extract_host_and_ports(remote_host, remote_port, local_port)
@@ -258,9 +258,9 @@ class RemoteClient(FileSystemClient):
         self.__port_forwarding_register.unregister(remote_host, remote_port)
 
     def port_forward_stopall(self):
-        '''
+        """
         Stop all port forwarding.
-        '''
+        """
         for remote_host in self.__port_forwarding_register._register:
             self.port_forward_stop(remote_host=remote_host)
 
@@ -269,11 +269,11 @@ class RemoteClient(FileSystemClient):
         return urlunparse(parsed_uri._replace(netloc='localhost:{}'.format(self.port_forward(parsed_uri.netloc))))
 
     def show_port_forwards(self):
-        '''
+        """
         Return a list of active port forwards, in the form:
         (local, remote, obj)
         where `obj` is the value returned from `_port_forward_start`.
-        '''
+        """
         if len(self.__port_forwarding_register._register) == 0:
             print("No port forwards currently in use.")
         for remote_host, (local_port, _) in self.__port_forwarding_register._register.items():

--- a/omniduct/remotes/ssh_paramiko.py
+++ b/omniduct/remotes/ssh_paramiko.py
@@ -166,7 +166,7 @@ def forward_tunnel(local_port, remote_host, remote_port, transport):
 
 
 def get_host_port(spec, default_port=22):
-    "parse 'hostname:22' into a host and port, with the port optional"
+    """parse 'hostname:22' into a host and port, with the port optional"""
     args = (spec.split(':', 1) + [default_port])[:2]
     args[1] = int(args[1])
     return args[0], args[1]

--- a/omniduct/restful/base.py
+++ b/omniduct/restful/base.py
@@ -6,23 +6,23 @@ from omniduct.utils.magics import MagicsProvider, process_line_arguments
 
 
 class RestClientBase(Duct):
-    '''
+    """
     This is a simple wrapper around the requests library to simplify the use
     of RESTful clients with omniduct. This allows all the automatic features
     around port forwarding from remote hosts to be inherited. This client can
     be used directly, or decorated by subclasses which can add methods
     specific to any REST service; and internally use `request` and `request_json`
     to access various endpoints.
-    '''
+    """
 
     DUCT_TYPE = Duct.Type.RESTFUL
 
     def __init__(self, server_protocol='http', assume_json=False, endpoint_prefix='', **kwargs):
-        '''
+        """
         This is a shim __init__ function that passes all arguments onto
         `self._init`, which is implemented by subclasses. This allows subclasses
         to instantiate themselves with arbitrary parameters.
-        '''
+        """
         Duct.__init_with_kwargs__(self, kwargs, port=80)
 
         self.server_protocol = server_protocol

--- a/omniduct/utils/config.py
+++ b/omniduct/utils/config.py
@@ -25,7 +25,7 @@ class ConfigurationRegistry(object):
 
     def register(self, key, description=None, default=None, onchange=None, onload=None,
                  type=None, host=None):
-        '''
+        """
         Register a configuration key that can be set by the user. As noted in the
         class level documentation, these keys should not lead to changes in the
         output of omniduct functions. The same code should generate the same results
@@ -42,7 +42,7 @@ class ConfigurationRegistry(object):
          - type : Values set will be of `isinstance(val, type)`
 
         * If not specified, these fields default to None.
-        '''
+        """
         if key in dir(self):
             raise KeyError("Key `{0}` cannot be registered as it conflicts with a method of OmniductConfiguration.".format(key))
         if key in self._register:
@@ -66,11 +66,11 @@ class ConfigurationRegistry(object):
         }
 
     def show(self):
-        '''
+        """
         Pretty print the configuration options available to be set, as well as
         their current values, descriptions and the module from which they were
         registered.
-        '''
+        """
         for key in sorted(self._register.keys()):
             desc = self._register[key].get('description')
             if desc is None:
@@ -131,20 +131,20 @@ class Configuration(ConfigurationRegistry):
                     "Configuration file at {0} cannot be loaded. Perhaps try deleting it.".format(self.__config_path))
 
     def all(self):
-        '''
+        """
         Return a dictionary containing all configuration keys. Note that this is
         the actual dictionary storing the configuration options, so modifying
         this dictionary will modify the configuration options *without* running
         the standard checks.
-        '''
+        """
         return self._config
 
     def show(self):
-        '''
+        """
         Pretty print the configuration options available to be set, as well as
         their current values, descriptions and the module from which they were
         registered.
-        '''
+        """
         for key in sorted(self._register.keys()):
             desc = self._register[key].get('description')
             if desc is None:
@@ -155,12 +155,12 @@ class Configuration(ConfigurationRegistry):
             print('\t({0})'.format(self._register[key]['host']))
 
     def __setattr__(self, key, value):
-        '''
+        """
         Allow setting configuration options using the standard python attribute
         methods, as described in the class documentation.
 
         Attributes prefixed with '_' are loaded from this class.
-        '''
+        """
         if key.startswith('_'):
             object.__setattr__(self, key, value)
         elif key in self._register:
@@ -175,12 +175,12 @@ class Configuration(ConfigurationRegistry):
             raise KeyError("No such configuration key `{0}`.".format(key))
 
     def __getattr__(self, key):
-        '''
+        """
         Allow retrieval of configuration keys using standard python atribute
         methods, as described in the class documentation.
 
         Attributes prefixed with '_' are loaded from this class.
-        '''
+        """
         if key.startswith('_'):
             return object.__getattr__(self, key)
         if key in self._register:
@@ -195,7 +195,7 @@ class Configuration(ConfigurationRegistry):
         raise AttributeError("No such configuration key `{0}`.".format(key))
 
     def reset(self, *keys, **target_config):
-        '''
+        """
         Reset all configuration keys specifed to their default values, or values
         specified in `target_config`. If both `keys` and `target_config` are
         specified, `keys` acts to both filter the keys of `target_config` and add
@@ -206,7 +206,7 @@ class Configuration(ConfigurationRegistry):
 
         If no keys are specified, reset all keys:
         >>> config.reset()
-        '''
+        """
         if len(keys) == 0:
             keys = set(list(self._register.keys()) + list(target_config.keys()))
 
@@ -235,7 +235,7 @@ class Configuration(ConfigurationRegistry):
         return {key: d[key] for key in keys if key in d}
 
     def save(self, filename=None, keys=None, replace=None):
-        '''
+        """
         Save the current configuration as a JSON file. Accepted arguments are:
          - filename : The location of the file to be saved. If not specified,
             default configuration location is used (and autoloaded on startup).
@@ -246,7 +246,7 @@ class Configuration(ConfigurationRegistry):
             maintained except where they conflict with the keys specified. The
             default value is `None`, in which case it maps to `True` if keys=None,
             or `False` if specific keys are specified. (default=None)
-        '''
+        """
         filename = filename or self._config_path
         filename = os.path.join(ensure_path_exists(os.path.dirname(filename)), os.path.basename(filename))
         config = {}
@@ -265,7 +265,7 @@ class Configuration(ConfigurationRegistry):
             f.write(json_config)
 
     def load(self, filename=None, keys=None, replace=None, force=False):
-        '''
+        """
         Load a configuration from the disk. Accepted arguments are:
          - filename : The location of the configuration. By default, this will
             point to the automatically loaded configuration file.
@@ -280,7 +280,7 @@ class Configuration(ConfigurationRegistry):
             but in some cases (such as startup), the register has yet to be filled,
             and so results in spouts spurious warnings. This allows one to bypass
             all checks.
-        '''
+        """
         filename = filename or self._config_path
         if replace is None:
             replace = True if keys is None else False

--- a/omniduct/utils/debug.py
+++ b/omniduct/utils/debug.py
@@ -20,7 +20,7 @@ config.register('logging_level',
 
 
 class StatusLogger(object):
-    '''
+    """
     StatusLogger is a wrapper around `logging.Logger` that allows for consistent
     treatment of logging messages. While not strictly required,
     it simplifies and abstracts the usage of the logging module within omniduct.
@@ -33,7 +33,7 @@ class StatusLogger(object):
 
     StatusLogger will automatically detect the context of the logged message, and
     include it in the log messages.
-    '''
+    """
 
     def __init__(self, auto_scoping=False):
         self.__scopes = []
@@ -97,17 +97,17 @@ class StatusLogger(object):
 
     @property
     def current_scopes(self):
-        '''
+        """
         The current logger scopes. This is not designed to work with multiple
         threads.
-        '''
+        """
         return detect_scopes()
 
     @property
     def current_scope_props(self):
-        ''''
+        """
         The properties for the most nested manual scope.
-        '''
+        """
         if len(self.__scopes) == 0:
             return None
         return self.__scopes[-1]
@@ -125,10 +125,10 @@ class StatusLogger(object):
         return self._progress_bar
 
     def progress(self, progress, complete=False):
-        '''
+        """
         Set the current progress to `progress`, and if not already showing, display
         a progress bar. If `complete` evaluates to True, then finish displaying the progress.
-        '''
+        """
         complete = complete or (self.current_scope_props is None)  # Only leave progress bar open if within a scope
         if config.logging_level <= logging.INFO:
             self.__get_progress_bar().update(progress)
@@ -139,10 +139,10 @@ class StatusLogger(object):
     # Logging emulation
 
     def __get_logger_instance(self, context=None):
-        '''
+        """
         Get a `logger.Logger` instance for the provided context; inferring the
         context from the runtime stack if the provided context is `None`.
-        '''
+        """
         if context is None:
             try:
                 caller = inspect.stack()[2]
@@ -152,18 +152,18 @@ class StatusLogger(object):
         return logging.getLogger(context)
 
     def __getattr__(self, name):
-        '''
+        """
         Return the attributes of the wrapped `logging.Logger` instance rather
         than this one (unless the property actually exists in StatusLogger).
-        '''
+        """
         return getattr(self.__get_logger_instance(), name)
 
     def setLevel(self, level, context=None):
-        '''
+        """
         Add a keyword argument `context` to the standard `setLevel` method, in
         order to allow for fine-grained logging levels, while retaining the
         simplicity of a single "logger" instance.
-        '''
+        """
         self.__get_logger_instance(context).setLevel(level)
 
 
@@ -191,9 +191,9 @@ def detect_scopes():
 
 
 class LoggingHandler(logging.Handler):
-    '''
+    """
     An implementation of Logging.Handler to render the logging methods shown in Omniduct and derivatives.
-    '''
+    """
 
     def __init__(self, level=logging.NOTSET):
         logging.Handler.__init__(self, level=level)
@@ -245,12 +245,12 @@ class LoggingHandler(logging.Handler):
 
 
 def logging_scope(name, *wargs, **wkwargs):
-    '''
+    """
     A decorator to add the decorated function as a new logging scope, with name `name`.
     All additional arguments are passed to `StatusLogger._scope_enter`. Current
     supported keyword arguments are "timed", in which case when the scope closes,
     the duration of the call is shown.
-    '''
+    """
     def logging_scope(func, *args, **kwargs):
         logger._scope_enter(name, *wargs, **wkwargs)
         success = True


### PR DESCRIPTION
> For consistency, always use """triple double quotes""" around docstrings.
* https://www.python.org/dev/peps/pep-0257/#what-is-a-docstring
