### PR TITLE
ensure file exists when opening to read

### DIFF
--- a/omniduct/filesystems/base.py
+++ b/omniduct/filesystems/base.py
@@ -443,6 +443,8 @@ class FileSystemClient(Duct, MagicsProvider):
         Returns:
             FileSystemFile or file-like: An opened file-like object.
         """
+        if 'r' in mode:
+            assert self.isfile(path), 'No such file {}'.format(path)
         return self.connect()._open(path, mode=mode)
 
     def _open(self, path, mode):


### PR DESCRIPTION
Currently, when opening a non-existent file to read, no error is thrown and the empty string is read. 

@matthewwardrop 