### PR TITLE
handle status is None from presto

### DIFF
--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -84,7 +84,9 @@ class PrestoClient(DatabaseClient):
             status = cursor.poll()
             if not async:
                 logger.progress(0)
-                while status['stats']['state'] != "FINISHED":
+                # status None means command executed successfully
+                # See https://github.com/dropbox/PyHive/blob/master/pyhive/presto.py#L234
+                while status is not None and status['stats']['state'] != "FINISHED":
                     if status['stats'].get('totalSplits', 0) > 0:
                         pct_complete = round(status['stats']['completedSplits'] / float(status['stats']['totalSplits']), 4)
                         logger.progress(pct_complete * 100)


### PR DESCRIPTION
### Summary 
bugfix for status is None

e.g. this query would fail
```
In [4]: %%presto use_cache=False
   ...: SET SESSION distributed_join=True;
```

### Reviewers
@matthewwardrop @anotheranshu