### PR TITLE
support write to s3

### DIFF
--- a/omniduct/filesystems/base.py
+++ b/omniduct/filesystems/base.py
@@ -529,7 +529,7 @@ class FileSystemClient(Duct, MagicsProvider):
                 copied into destination folder, and will throw an error if path
                 does not resolve to a directory.
             dest (str): The destination path on filesystem (`fs`). If not
-                specified, the file/folder is uploaded into the default path,
+                specified, the file/folder is downloaded into the default path,
                 usually one's home folder. If `dest` ends with '/',
                 and corresponds to a directory, the contents of source will be
                 copied instead of copying the entire folder. If `dest` is

--- a/omniduct/filesystems/s3.py
+++ b/omniduct/filesystems/s3.py
@@ -180,11 +180,18 @@ class S3Client(FileSystemClient):
 
         if not binary:
             body = body.decode('utf-8')
-
+        if offset > 0:
+            body = body[offset:]
+        if size >= 0:
+            body = body[:size]
         return body
 
     def _file_append_(self, path, s, binary):
-        raise NotImplementedError("Support for S3 write operations has yet to be implemented.")
+        raise NotImplementedError("Support for S3 append operation has yet to be implemented.")
 
     def _file_write_(self, path, s, binary):
-        raise NotImplementedError("Support for S3 write operations has yet to be implemented.")
+        obj = self._resource.Object(self.bucket, path)
+        if not binary:
+            s = s.encode('utf-8')
+        obj.put(Body=s)
+        return True


### PR DESCRIPTION
### Summary
Support write to S3. letting FSClients implement _open ended up making the resulting File object inconsistent with what the base expects so also implemented read/write for local fs. 

### Reviewers
@matthewwardrop 