### PR TITLE
move shemas to a mixin

### DIFF
--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -16,9 +16,10 @@ from omniduct.utils.debug import logger
 from omniduct.utils.processes import Timeout, run_in_subprocess
 
 from .base import DatabaseClient
+from .schemas import SchemasMixin
 
 
-class HiveServer2Client(DatabaseClient):
+class HiveServer2Client(DatabaseClient, SchemasMixin):
     """
     This Duct connects to an Apache HiveServer2 server instance using the
     `pyhive` or `impyla` libraries.
@@ -126,6 +127,7 @@ class HiveServer2Client(DatabaseClient):
         self.__hive = None
         self._sqlalchemy_engine = None
         self._sqlalchemy_metadata = None
+        self._schemas = None
 
     def _execute(self, statement, cursor=None, async=False, poll_interval=1):
         """

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -13,9 +13,10 @@ from omniduct.utils.debug import logger
 
 from .._version import __version__
 from .base import DatabaseClient
+from .schemas import SchemasMixin
 
 
-class PrestoClient(DatabaseClient):
+class PrestoClient(DatabaseClient, SchemasMixin):
     """
     This Duct connects to a Facebook Presto server instance using the `pyhive`
     library.
@@ -179,23 +180,3 @@ class PrestoClient(DatabaseClient):
 
     def _table_props(self, table, **kwargs):
         raise NotImplementedError
-
-    @property
-    def schemas(self):
-        """
-        This object has as attributes the schemas on the current catalog. These
-        schema objects in turn have the tables as SQLAlchemy `Table` objects.
-        This allows tab completion and exploration of Presto Databases.
-        """
-        from werkzeug import LocalProxy
-
-        def get_schemas():
-            if not getattr(self, '_schemas', None):
-                self.connect()
-                try:
-                    from .schemas import Schemas
-                    self._schemas = Schemas(self._sqlalchemy_metadata)
-                except ImportError:
-                    logger.warning('cannot import Schemas, perhaps sqlalchemy is not up to date')
-            return self._schemas
-        return LocalProxy(get_schemas)

--- a/omniduct/databases/sqlalchemy.py
+++ b/omniduct/databases/sqlalchemy.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
-import pandas as pd
 
 from .base import DatabaseClient
+from .schemas import SchemasMixin
 
 
-class SQLAlchemyClient(DatabaseClient):
+class SQLAlchemyClient(DatabaseClient, SchemasMixin):
 
     PROTOCOLS = ['sqlalchemy', 'firebird', 'mssql', 'mysql', 'oracle', 'postgresql', 'sybase']
 
@@ -37,13 +37,17 @@ class SQLAlchemyClient(DatabaseClient):
 
     def _connect(self):
         import sqlalchemy
+
         self.engine = sqlalchemy.create_engine(self.db_uri)
+        self._sqlalchemy_metadata = sqlalchemy.MetaData(self.engine)
 
     def _is_connected(self):
         return self.engine is not None
 
     def _disconnect(self):
         self.engine = None
+        self._sqlalchemy_metadata = None
+        self._schemas = None
 
     def _execute(self, statement, query=True, cursor=None, **kwargs):
         if cursor:


### PR DESCRIPTION
### Summary
 * move schemas to a mixin class
 * add sqlalchemy metadata to SqlAlchemyDatabase
 * make the print format of tables easier to read (use a dataframe)

```
In [16]: dbduct.schemas.dan_frank.testing
Out[16]:
  name     type
0  foo  INTEGER
1  bar  INTEGER
```

### Testing Done
Tested the sqlalchemy database, but don't have access to presto or hive anymore 

 