### PR TITLE
update kwarg async -> asynchronous for py3.7 compatibility

### DIFF
--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -162,7 +162,7 @@ class DatabaseClient(Duct, MagicsProvider):
 
     @render_statement
     @quirk_docs('_execute')
-    def execute(self, statement, cleanup=True, async=False, cursor=None, **kwargs):
+    def execute(self, statement, cleanup=True, asynchronous=False, cursor=None, **kwargs):
         """
         This method executes a given statement against the relevant database,
         returning the results as a standard DBAPI2 compatible cursor. Where
@@ -174,7 +174,7 @@ class DatabaseClient(Duct, MagicsProvider):
                 (possibly templated).
             cleanup (bool): Whether statement should be cleaned up before
                 computing the hash used to cache results.
-            async (bool): Whether the cursor should be returned before the
+            asynchronous (bool): Whether the cursor should be returned before the
                 server-side query computation is complete and the relevant
                 results downloaded.
             cursor (DBAPI2 cursor):  Rather than creating a new cursor, execute
@@ -198,8 +198,8 @@ class DatabaseClient(Duct, MagicsProvider):
         assert len(statements) > 0, "No non-empty statements were provided."
 
         for statement in statements[:-1]:
-            cursor = self.connect()._execute(statement, cursor=cursor, async=False, **kwargs)
-        cursor = self.connect()._execute(statements[-1], cursor=cursor, async=async, **kwargs)
+            cursor = self.connect()._execute(statement, cursor=cursor, asynchronous=False, **kwargs)
+        cursor = self.connect()._execute(statements[-1], cursor=cursor, asynchronous=asynchronous, **kwargs)
 
         return cursor
 
@@ -236,7 +236,7 @@ class DatabaseClient(Duct, MagicsProvider):
         Returns:
             The results of the query formatted as nominated.
         """
-        cursor = self.execute(statement, async=False, template=False, **kwargs)
+        cursor = self.execute(statement, asynchronous=False, template=False, **kwargs)
 
         # Some DBAPI2 cursor implementations error if attempting to extract
         # data from an empty cursor, and if so, we simply return None.
@@ -268,7 +268,7 @@ class DatabaseClient(Duct, MagicsProvider):
             iterator: An iterator over objects of the nominated format or, if
                 batched, a list of such objects.
         """
-        cursor = self.execute(statement, async=False, **kwargs)
+        cursor = self.execute(statement, asynchronous=False, **kwargs)
         formatter = self._get_formatter(format, cursor, **format_opts)
 
         for row in formatter.stream(batch=batch):
@@ -510,7 +510,7 @@ class DatabaseClient(Duct, MagicsProvider):
     # Table properties
 
     @abstractmethod
-    def _execute(self, statement, cursor=None, async=False, **kwargs):
+    def _execute(self, statement, cursor=None, asynchronous=False, **kwargs):
         pass
 
     def _push(self, df, table, if_exists='fail', **kwargs):

--- a/omniduct/databases/druid.py
+++ b/omniduct/databases/druid.py
@@ -39,7 +39,7 @@ class DruidClient(DatabaseClient):
         self.__druid = None
 
     # Querying
-    def _execute(self, statement, cursor=None, async=False):
+    def _execute(self, statement, cursor=None, asynchronous=False):
         cursor = cursor or self.__druid.cursor()
         cursor.execute(statement)
         return cursor

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -129,7 +129,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         self._sqlalchemy_metadata = None
         self._schemas = None
 
-    def _execute(self, statement, cursor=None, async=False, poll_interval=1):
+    def _execute(self, statement, cursor=None, asynchronous=False, poll_interval=1):
         """
         Additional Parameters:
             poll_interval (int): Default delay in seconds between consecutive
@@ -140,9 +140,9 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
 
         if self.driver == 'pyhive':
             from TCLIService.ttypes import TOperationState
-            cursor.execute(statement, async=True)
+            cursor.execute(statement, **{'async': True})  # py3.7 compatibility
 
-            if not async:
+            if not asynchronous:
                 status = cursor.poll().operationState
                 while status in (TOperationState.INITIALIZED_STATE, TOperationState.RUNNING_STATE):
                     log_offset = self._log_status(cursor, log_offset)
@@ -151,7 +151,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
 
         elif self.driver == 'impyla':
             cursor.execute_async(statement)
-            if not async:
+            if not asynchronous:
                 while cursor.is_executing():
                     log_offset = self._log_status(cursor, log_offset)
                     time.sleep(poll_interval)

--- a/omniduct/databases/neo4j.py
+++ b/omniduct/databases/neo4j.py
@@ -41,7 +41,7 @@ class Neo4jClient(DatabaseClient):
         self.__driver = None
 
     # Querying
-    def _execute(self, statement, cursor=None, async=False):
+    def _execute(self, statement, cursor=None, asynchronous=False):
         with self.__driver.session() as session:
             result = session.run(statement)
 

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -94,7 +94,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         self._schemas = None
 
     # Querying
-    def _execute(self, statement, cursor=None, async=False):
+    def _execute(self, statement, cursor=None, asynchronous=False):
         """
         If something goes wrong, `PrestoClient` will attempt to parse the error
         log and present the user with useful debugging information. If that fails,
@@ -105,7 +105,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
             cursor = cursor or self.__presto.cursor()
             cursor.execute(statement)
             status = cursor.poll()
-            if not async:
+            if not asynchronous:
                 logger.progress(0)
                 # status None means command executed successfully
                 # See https://github.com/dropbox/PyHive/blob/master/pyhive/presto.py#L234

--- a/omniduct/databases/stub.py
+++ b/omniduct/databases/stub.py
@@ -22,7 +22,7 @@ class StubDatabaseClient(DatabaseClient):
 
     # Database operations
 
-    def _execute(self, statement, cursor=None, async=False, **kwargs):
+    def _execute(self, statement, cursor=None, asynchronous=False, **kwargs):
         raise NotImplementedError
 
     def _table_list(self, **kwargs):


### PR DESCRIPTION
### Summary
py3.7 uses keyword async; omniduct uses this as a kwarg making it syntactically invalid.

### Testing Done 
omniduct imports successfully in py3.7

### FYI
@kandouss