### PR TITLE
handle None cursor

### DIFF
--- a/omniduct/caches/base.py
+++ b/omniduct/caches/base.py
@@ -48,6 +48,10 @@ def cached_method(
 
         if _renew or not _cache.has_key(_key, namespace=_namespace):  # noqa: has_key is not of a dictionary here
             value = method(self, **kwargs)
+            if value is None:
+                logger.warning("Method value returned None. Not saving to cache.")
+                return
+
             try:
                 _cache.set(
                     _key,

--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -613,7 +613,7 @@ class DatabaseClient(Duct, MagicsProvider):
         raise NotImplementedError
 
     def _cursor_empty(self, cursor):
-        return False
+        return cursor is None
 
     def _parse_namespaces(self, name, level=0, defaults=None):
         return ParsedNamespaces.from_name(

--- a/omniduct/databases/sqlalchemy.py
+++ b/omniduct/databases/sqlalchemy.py
@@ -86,9 +86,6 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
         return df.to_sql(name=table.table, schema=table.database, con=self.engine,
                          index=False, if_exists=if_exists, **kwargs)
 
-    def _cursor_empty(self, cursor):
-        return False
-
     def _table_list(self, **kwargs):
         return self.query("SHOW TABLES", **kwargs)
 


### PR DESCRIPTION
When running queries that are not designed to return results (e.g. DROP TABLE, GRANT, etc) the current `query()` method raises a somewhat mysterious exception. This PR warns the user that None results are not being saved to cache instead. 

@matthewwardrop 