### PR TITLE
Only install PyHive for default HiveServer2Client driver

### DIFF
--- a/omniduct/_version.py
+++ b/omniduct/_version.py
@@ -39,7 +39,6 @@ __optional_dependencies__ = {
 
     'hiveserver2': [
         'pyhive[hive]>=0.4',  # Primary client
-        'impyla>=0.14.0',  # Primary client
         'thrift>=0.10.0',  # Thrift dependency which seems not to be installed with upstream deps
     ],
 

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -86,7 +86,14 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
     def _connect(self):
         from sqlalchemy import create_engine, MetaData
         if self.driver == 'pyhive':
-            import pyhive.hive
+            try:
+                import pyhive.hive
+            except ImportError:
+                raise ImportError("""
+                    Omniduct is attempting to use the 'pyhive' driver, but it
+                    is not installed. Please either install the pyhive package,
+                    or reconfigure this Duct to use the 'impyla' driver.
+                    """)
             self.__hive = pyhive.hive.connect(host=self.host,
                                               port=self.port,
                                               auth=self.auth_mechanism,
@@ -100,7 +107,11 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
             try:
                 import impala.dbapi
             except ImportError:
-                raise ImportError("Please install impyla or specify driver='pyhive'.")
+                raise ImportError("""
+                    Omniduct is attempting to use the 'impyla' driver, but it
+                    is not installed. Please either install the impyla package,
+                    or reconfigure this Duct to use the 'pyhive' driver.
+                    """)
             self.__hive = impala.dbapi.connect(host=self.host,
                                                port=self.port,
                                                auth_mechanism=self.auth_mechanism,

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -97,7 +97,10 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
             self._sqlalchemy_engine = create_engine('hive://{}:{}/{}'.format(self.host, self.port, self.schema))
             self._sqlalchemy_metadata = MetaData(self._sqlalchemy_engine)
         elif self.driver == 'impyla':
-            import impala.dbapi
+            try:
+                import impala.dbapi
+            except ImportError:
+                raise ImportError("Please install impyla or specify driver='pyhive'.")
             self.__hive = impala.dbapi.connect(host=self.host,
                                                port=self.port,
                                                auth_mechanism=self.auth_mechanism,


### PR DESCRIPTION
Since `HiveServer2Client` defaults to using PyHive for its driver, it seems like we don't really need to install `impyla` and `pyhive`. I think we should drop `impyla` from the default install reqs and raise if the user tries to use it for the Hive backend.

I came across this recently when a few new employees installing Python on OSX via `brew install python` (which defaults to 3.7 now, problematic given all the packages lagging in support...) and `omniduct[hive]` failed due to `thriftpy` via `impyla`. (https://github.com/eleme/thriftpy/issues/333)
Impyla crashes on 3.7 on its own (https://github.com/cloudera/impyla/issues/312) as well.

The 3.7 issue aside (PyHive is fixed: https://github.com/dropbox/PyHive/pull/232), wdyt of installing only PyHive by default?