### PR TITLE
Hive fix

### DIFF
--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -598,6 +598,7 @@ class DatabaseClient(Duct, MagicsProvider):
                 `DatabaseClient._dataframe_to_table`.
         """
         assert if_exists in {'fail', 'replace', 'append'}
+        print(kwargs)
         self.connect()._dataframe_to_table(df, self._parse_namespaces(table), if_exists=if_exists, **kwargs)
 
     # Table properties

--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -598,7 +598,6 @@ class DatabaseClient(Duct, MagicsProvider):
                 `DatabaseClient._dataframe_to_table`.
         """
         assert if_exists in {'fail', 'replace', 'append'}
-        print(kwargs)
         self.connect()._dataframe_to_table(df, self._parse_namespaces(table), if_exists=if_exists, **kwargs)
 
     # Table properties

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -273,12 +273,10 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
                 use instead of default mapping.
         """
         table = self._parse_namespaces(table, defaults={'schema': self.username})
-        print(table)
         use_hive_cli = use_hive_cli or self.push_using_hive_cli
         partition = partition or {}
         table_props = table_props or {}
         dtype_overrides = dtype_overrides or {}
-        print(kwargs)
         # Try using SQLALchemy method
         if not use_hive_cli:
             if partition or table_props or dtype_overrides:
@@ -367,7 +365,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         )
         try:
             stmts = '\n'.join([cts.replace("`", ""), lds])
-            # print(stmts)
             # logger.debug(stmts)
             proc = self._run_in_hivecli(stmts)
             if proc.returncode != 0:
@@ -385,7 +382,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
 
     def _table_list(self, namespace, like='*', **kwargs):
         schema = namespace.name or self.schema
-        print(schema, namespace.name, self.schema)
 
         return self.query("SHOW TABLES IN {0} '{1}'".format(schema, like),
                           **kwargs)
@@ -431,7 +427,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         # Turn hive command into quotable string.
         double_escaped = re.sub('\\' * 2, '\\' * 4, cmd)
         sys_cmd = 'hive -e "{0}"'.format(re.sub('"', '\\"', double_escaped))
-        print(sys_cmd)
         # Execute command in a subprocess.
         if self.remote:
             proc = self.remote.execute(sys_cmd)

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -236,7 +236,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
     ):
         """
         If `use_hive_cli` (or if not specified `.push_using_hive_cli`) is
-        `True`, a `CRETE TABLE` statement will be automatically generated based
+        `True`, a `CREATE TABLE` statement will be automatically generated based
         on the datatypes of the DataFrame (unless overwritten by
         `dtype_overrides`). The `DataFrame` will then be exported to a CSV
         compatible with Hive and uploaded (if necessary) to the remote, before

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -236,7 +236,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
     ):
         """
         If `use_hive_cli` (or if not specified `.push_using_hive_cli`) is
-        `True`, a `CREATE TABLE` statement will be automatically generated based
+        `True`, a `CRETE TABLE` statement will be automatically generated based
         on the datatypes of the DataFrame (unless overwritten by
         `dtype_overrides`). The `DataFrame` will then be exported to a CSV
         compatible with Hive and uploaded (if necessary) to the remote, before
@@ -277,7 +277,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         partition = partition or {}
         table_props = table_props or {}
         dtype_overrides = dtype_overrides or {}
-
+        print(kwargs)
         # Try using SQLALchemy method
         if not use_hive_cli:
             if partition or table_props or dtype_overrides:
@@ -364,6 +364,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         )
         try:
             stmts = '\n'.join([cts, lds])
+            print(stmts)
             logger.debug(stmts)
             proc = self._run_in_hivecli(stmts)
             if proc.returncode != 0:
@@ -381,6 +382,8 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
 
     def _table_list(self, namespace, like='*', **kwargs):
         schema = namespace.name or self.schema
+        print(schema, namespace.name, self.schema)
+
         return self.query("SHOW TABLES IN {0} '{1}'".format(schema, like),
                           **kwargs)
 


### PR DESCRIPTION
Fixes #68.

It seems like the backticks around the namespace/table names sent to `hive -e "...."` were screwing with the remote execution of the `CREATE TABLE` and `LOAD DATA` Hive commands. You should be able to escape them with `\` but I couldn't get that to work for whatever reason.