### PR TITLE
Only check dependency for protocol being used by Duct

### DIFF
--- a/omniduct/duct.py
+++ b/omniduct/duct.py
@@ -274,7 +274,7 @@ class Duct(with_metaclass(ProtocolRegisteringQuirkDocumentedABCMeta, object)):
             to the cache.
         """
 
-        check_dependencies(self.PROTOCOLS)
+        check_dependencies([protocol])
 
         self.protocol = protocol
         self.name = name or self.__class__.__name__


### PR DESCRIPTION
Since Snowflake was added as a new SQLAlchemy protocol in #64, initializing any `Duct` with a SQLAlchemy dialect checks for the presence of `snowflake` dependencies, causing a `RunTimeError` from `check_dependencies`.

With this change, `Duct.__init__()` will only check for the protocol the particular instance is using, rather than all protocols available to the Duct class type.

@danfrankj @matthewwardrop 