### PR TITLE
Modify Hive CLI backtick escape sequence for non-remote execution

### DIFF
--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -434,8 +434,9 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         """Run a query using hive cli in a subprocess."""
         # Turn hive command into quotable string.
         double_escaped = re.sub('\\' * 2, '\\' * 4, cmd)
+        backtick_escape = '\\\\\\`' if self.remote else '\\`'
         sys_cmd = 'hive -e "{0}"'.format(re.sub('"', '\\"', double_escaped)) \
-                                 .replace('`', '\\\\\\`')
+                                 .replace('`', backtick_escape)
         # Execute command in a subprocess.
         if self.remote:
             proc = self.remote.execute(sys_cmd)


### PR DESCRIPTION
The number of backslashes in the Hive CLI escape sequence for backticks needs to be modified for remote (SSH) and non-remote (local) execution.
cc @matthewwardrop 