### PR TITLE
add default configurable format opts, in particular lowercase_columns

### DIFF
--- a/omniduct/databases/_cursor_formatters.py
+++ b/omniduct/databases/_cursor_formatters.py
@@ -9,6 +9,7 @@ class CursorFormatter(object):
 
     def __init__(self, cursor, **kwargs):
         self.cursor = cursor
+        self.lowercase_columns = kwargs.pop('lowercase_columns', False)
         self.init(**kwargs)
 
     def init(self):
@@ -16,7 +17,7 @@ class CursorFormatter(object):
 
     @property
     def column_names(self):
-        return [c[0] for c in self.cursor.description]
+        return [c[0].lower() if self.lowercase_columns else c[0] for c in self.cursor.description]
 
     @property
     def column_formats(self):

--- a/omniduct/databases/_cursor_formatters.py
+++ b/omniduct/databases/_cursor_formatters.py
@@ -4,12 +4,21 @@ import six
 
 from omniduct.utils.debug import logger
 
+COLUMN_NAME_FORMATTERS = {
+    'lowercase': lambda x: x.lower(),
+    'uppercase': lambda x: x.upper()
+}
+
 
 class CursorFormatter(object):
 
     def __init__(self, cursor, **kwargs):
         self.cursor = cursor
-        self.lowercase_columns = kwargs.pop('lowercase_columns', False)
+        column_name_formatter = kwargs.pop('column_name_formatter', lambda x: x)
+        self.column_name_formatter = (
+            column_name_formatter if callable(column_name_formatter)
+            else COLUMN_NAME_FORMATTERS[column_name_formatter]
+        )
         self.init(**kwargs)
 
     def init(self):
@@ -17,7 +26,7 @@ class CursorFormatter(object):
 
     @property
     def column_names(self):
-        return [c[0].lower() if self.lowercase_columns else c[0] for c in self.cursor.description]
+        return [self.column_name_formatter(c[0]) for c in self.cursor.description]
 
     @property
     def column_formats(self):

--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -71,7 +71,10 @@ class DatabaseClient(Duct, MagicsProvider):
     NAMESPACE_SEPARATOR = '.'
 
     @quirk_docs('_init', mro=True)
-    def __init__(self, session_properties=None, templates=None, template_context=None, **kwargs):
+    def __init__(
+        self, session_properties=None, templates=None, template_context=None, default_format_opts=None,
+        **kwargs
+    ):
         """
         session_properties (dict): A mapping of default session properties
             to values. Interpretation is left up to implementations.
@@ -87,6 +90,7 @@ class DatabaseClient(Duct, MagicsProvider):
         self._template_context = template_context or {}
         self._sqlalchemy_engine = None
         self._sqlalchemy_metadata = None
+        self._default_format_opts = default_format_opts or {}
 
         self._init(**kwargs)
 
@@ -353,7 +357,8 @@ class DatabaseClient(Duct, MagicsProvider):
         if not (inspect.isclass(formatter) and issubclass(formatter, _cursor_formatters.CursorFormatter)):
             assert formatter in self.CURSOR_FORMATTERS, "Invalid format '{}'. Choose from: {}".format(formatter, ','.join(self.CURSOR_FORMATTERS.keys()))
             formatter = self.CURSOR_FORMATTERS[formatter]
-        return formatter(cursor, **kwargs)
+        format_opts = dict(list(self._default_format_opts.items()) + list(kwargs.items()))
+        return formatter(cursor, **format_opts)
 
     def stream_to_file(self, statement, file, format='csv', **kwargs):
         """

--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, print_function
 
 import hashlib
 import inspect
+import itertools
 import logging
 import os
 import sys
@@ -82,6 +83,8 @@ class DatabaseClient(Duct, MagicsProvider):
             templates can be added using `.template_add`.
         template_context (dict): The default template context to use when
             rendering templates.
+        default_format_opts (dict): The default formatting options passed to
+            cursor formatter.
         """
         Duct.__init_with_kwargs__(self, kwargs, port=self.DEFAULT_PORT)
 
@@ -357,7 +360,7 @@ class DatabaseClient(Duct, MagicsProvider):
         if not (inspect.isclass(formatter) and issubclass(formatter, _cursor_formatters.CursorFormatter)):
             assert formatter in self.CURSOR_FORMATTERS, "Invalid format '{}'. Choose from: {}".format(formatter, ','.join(self.CURSOR_FORMATTERS.keys()))
             formatter = self.CURSOR_FORMATTERS[formatter]
-        format_opts = dict(list(self._default_format_opts.items()) + list(kwargs.items()))
+        format_opts = dict(itertools.chain(self._default_format_opts.items(), kwargs.items()))
         return formatter(cursor, **format_opts)
 
     def stream_to_file(self, statement, file, format='csv', **kwargs):


### PR DESCRIPTION
### Summary
Some sqlalchemy engines (e.g. oracle, snowflake) do weird things like uppercase columns  automatically making the results of queries different between different engines. This PR attempts to address this by adding a configurable set of default format options for database ducts 

### Test Plan
Manual - duct configured do default lowercase_columns:true
![image](https://user-images.githubusercontent.com/616139/48172967-a41ba300-e2b6-11e8-8b93-a864f5c65e00.png)
