### PR TITLE
Check for empty dict in Duct config

### DIFF
--- a/omniduct/registry.py
+++ b/omniduct/registry.py
@@ -279,7 +279,7 @@ class DuctRegistry(object):
         if isinstance(config, dict):
             def max_consistent_depth(d):
                 depth = 0
-                if isinstance(d, dict):
+                if isinstance(d, dict) and len(d.keys()) > 0:
                     depths = []
                     for value in d.values():
                         depths.append(max_consistent_depth(value) + 1)

--- a/omniduct/registry.py
+++ b/omniduct/registry.py
@@ -279,7 +279,7 @@ class DuctRegistry(object):
         if isinstance(config, dict):
             def max_consistent_depth(d):
                 depth = 0
-                if isinstance(d, dict) and len(d.keys()) > 0:
+                if isinstance(d, dict) and d:
                     depths = []
                     for value in d.values():
                         depths.append(max_consistent_depth(value) + 1)


### PR DESCRIPTION
There are situations where the parsed `DuctRegistry` config can contain an empty `dict` at the bottom level, causing `register_from_config` to error out as follows:

```
File "/opt/miniconda/envs/test-environment/lib/python3.6/site-packages/omniduct/registry.py", line 286, in max_consistent_depth
--
  | [2018-12-05T01:50:30Z]     depth = max(depth, min(depths))
  | [2018-12-05T01:50:30Z] ValueError: min() arg is an empty sequence
```

This happens when the config looks something like this (@matthewwardrop @danfrankj you might remember this): 
```yaml
    spark:
        protocol: ssh
        host: Will be overwritten in ./config.py
        port: 22
        smartcards: {}
```
Returning 0 when the dict is empty should resolve this.
