### PR TITLE
Add support for cache pruning.

### DIFF
--- a/omniduct/_version.py
+++ b/omniduct/_version.py
@@ -27,6 +27,9 @@ __dependencies__ = [
     "pandas>=0.17.1",  # Various results including database queries are returned as pandas dataframes
     "sqlparse",  # Neatening of SQL based queries (mainly to avoid missing the cache)
     "sqlalchemy",  # Various integration endpoints in the database stack
+
+    # Utility libraries
+    "python-dateutil",  # Used for its `relativedelta` class for Cache instances
 ]
 
 PY2 = sys.version_info[0] == 2

--- a/omniduct/caches/base.py
+++ b/omniduct/caches/base.py
@@ -382,12 +382,18 @@ class Cache(Duct):
                 usage.update(metadata)
                 out.append(usage)
 
-        df = pandas.DataFrame(out)
+        if out:
+            df = pandas.DataFrame(out)
 
-        order = ['bytes', 'namespace', 'key', 'created', 'last_accessed']
-        order += sorted(set(df.columns).difference(order))
+            order = ['bytes', 'namespace', 'key', 'created', 'last_accessed']
+            order += sorted(set(df.columns).difference(order))
 
-        return df.sort_values('last_accessed', ascending=False).reset_index(drop=True)[order]
+            return df.sort_values('last_accessed', ascending=False).reset_index(drop=True)[order]
+
+        return pandas.DataFrame(
+            data=[],
+            columns=['bytes', 'namespace', 'key', 'created', 'last_accessed']
+        )
 
     # Cache pruning
 

--- a/omniduct/caches/filesystem.py
+++ b/omniduct/caches/filesystem.py
@@ -87,11 +87,11 @@ class FileSystemCache(Cache):
     def _namespace(self, namespace):
         if namespace is None:
             return '__default__'
-        assert isinstance(namespace, str)
+        assert isinstance(namespace, str) and namespace != 'config'
         return namespace
 
     def _get_namespaces(self):
-        return self.fs.listdir(self.path)
+        return [d for d in self.fs.listdir(self.path) if d != 'config']
 
     def _has_namespace(self, namespace):
         return self.fs.exists(self.fs.path_join(self.path, namespace))
@@ -107,6 +107,14 @@ class FileSystemCache(Cache):
 
     def _remove_key(self, namespace, key):
         return self.fs.remove(self.fs.path_join(self.path, namespace, key), recursive=True)
+
+    def _get_bytecount_for_key(self, namespace, key):
+        path = self.fs.path_join(self.path, namespace, key)
+        return sum([
+            f.bytes
+            for f in self.fs.dir(path)
+            if f.name.startswith('data.')
+        ])
 
     def _get_stream_for_key(self, namespace, key, stream_name, mode, create):
         path = self.fs.path_join(self.path, namespace, key)

--- a/omniduct/caches/filesystem.py
+++ b/omniduct/caches/filesystem.py
@@ -113,7 +113,6 @@ class FileSystemCache(Cache):
         return sum([
             f.bytes
             for f in self.fs.dir(path)
-            if f.name.startswith('data.')
         ])
 
     def _get_stream_for_key(self, namespace, key, stream_name, mode, create):


### PR DESCRIPTION
This patchset adds support for inspecting what is in the cache, and for pruning away older or larger stored keys.

It also fixes some minor issues with the the FilesystemCache, where `config` was presented as a namespace.