### PR TITLE
Allow DatabaseClients to specify default namespaces.

### DIFF
--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -77,6 +77,10 @@ class DatabaseClient(Duct, MagicsProvider):
     NAMESPACE_QUOTECHAR = '"'
     NAMESPACE_SEPARATOR = '.'
 
+    @property
+    def NAMESPACE_DEFAULT(self):
+        pass
+
     @quirk_docs('_init', mro=True)
     def __init__(
         self, session_properties=None, templates=None, template_context=None, default_format_opts=None,
@@ -720,7 +724,7 @@ class DatabaseClient(Duct, MagicsProvider):
             self.NAMESPACE_NAMES[:-level] if level > 0 else self.NAMESPACE_NAMES,
             quote_char=self.NAMESPACE_QUOTECHAR,
             separator=self.NAMESPACE_SEPARATOR,
-            defaults=defaults
+            defaults=self.NAMESPACE_DEFAULT if defaults is None else defaults
         )
 
     @quirk_docs('_table_list')

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -234,11 +234,11 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         elif if_exists == 'append':
             raise NotImplementedError("Append operations have not been implemented for {}.".format(self.__class__.__name__))
 
-        statement = "CREATE TABLE {table} AS ({statement})".format(
+        statements.append("CREATE TABLE {table} AS ({statement})".format(
             table=table,
             statement=statement
-        )
-        return self.execute(statement, **kwargs)
+        ))
+        return self.execute('\n'.join(statements), **kwargs)
 
     @override
     def _dataframe_to_table(

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -41,6 +41,14 @@ class PrestoClient(DatabaseClient, SchemasMixin):
     NAMESPACE_QUOTECHAR = '"'
     NAMESPACE_SEPARATOR = '.'
 
+    @property
+    @override
+    def NAMESPACE_DEFAULT(self):
+        return {
+            'catalog': self.catalog,
+            'schema': self.schema
+        }
+
     @override
     def _init(self, catalog='default', schema='default', server_protocol='http', source=None):
         """
@@ -167,15 +175,15 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         if if_exists == 'fail' and self.table_exists(table):
             raise RuntimeError("Table {} already exists!".format(table))
         elif if_exists == 'replace':
-            statements.append('DROP TABLE IF EXISTS {};'.format(table))
+            statements.append('DROP TABLE IF EXISTS {};\n'.format(table))
         elif if_exists == 'append':
             raise NotImplementedError("Append operations have not been implemented for {}.".format(self.__class__.__name__))
 
-        statement = "CREATE TABLE {table} AS ({statement})".format(
+        statements.append("CREATE TABLE {table} AS ({statement})".format(
             table=table,
             statement=statement
-        )
-        return self.execute(statement, **kwargs)
+        ))
+        return self.execute('\n'.join(statements), **kwargs)
 
     @override
     def _dataframe_to_table(self, df, table, if_exists='fail', **kwargs):


### PR DESCRIPTION
Currently the namespaces chosen as the default in `DatabaseClient` configuration is not propagated to utility methods like `table_list`, etc. This patch fixes this.