### PR TITLE
Add implementation of exasol Duct

### DIFF
--- a/omniduct/_version.py
+++ b/omniduct/_version.py
@@ -61,9 +61,7 @@ __optional_dependencies__ = {
         'snowflake-sqlalchemy',
     ],
 
-    'exasol': [
-        'pyexasol',
-    ],
+    'exasol': ['pyexasol'] if sys.version_info.major > 2 else [],
 
     # Filesystems
     'webhdfs': [

--- a/omniduct/_version.py
+++ b/omniduct/_version.py
@@ -61,6 +61,10 @@ __optional_dependencies__ = {
         'snowflake-sqlalchemy',
     ],
 
+    'exasol': [
+        'pyexasol',
+    ],
+
     # Filesystems
     'webhdfs': [
         'pywebhdfs',  # Primary client

--- a/omniduct/databases/exasol.py
+++ b/omniduct/databases/exasol.py
@@ -67,22 +67,28 @@ class ExasolClient(DatabaseClient):
         except Exception:
             pass
         self.__exasol = None
-        self.schema = None
 
     @override
     def _execute(self, statement, cursor, wait, session_properties, query=True):
-        #: pyexasol.ExaStatement has a similar interface to that of
+        # pyexasol.ExaStatement has a similar interface to that of
         # a DBAPI2 cursor.
         cursor = cursor or self.__exasol.execute(statement)
 
         # hacky: make the result look like a cursor.
-        # cursor.columns returns a dict we transform it into a
-        # flat list.
+        # cursor.columns returns a dict with the required attributes
         cursor.description = []
-        for key, value in cursor.columns().items():
-            description = [key]
-            description.extend(value.values())
-            cursor.description.append(description)
+        for key, values in cursor.columns().items():
+            cursor.description.append(
+                (
+                    key,
+                    values.get("type", None),
+                    values.get("size", None),
+                    values.get("size", None),
+                    values.get("precision", None),
+                    values.get("scale", None),
+                    True,
+                )
+            )
 
         return cursor
 

--- a/omniduct/databases/exasol.py
+++ b/omniduct/databases/exasol.py
@@ -1,0 +1,137 @@
+from __future__ import absolute_import
+
+from interface_meta import override
+
+from omniduct.utils.debug import logger
+
+from .base import DatabaseClient
+from . import _pandas
+
+
+class ExasolClient(DatabaseClient):
+    """
+    This client connects to an Exasol service using the `pyexasol` python library.
+    """
+
+    PROTOCOLS = ["exasol"]
+    DEFAULT_PORT = 8563
+    NAMESPACE_NAMES = ["schema", "table"]
+    NAMESPACE_QUOTECHAR = '"'
+    NAMESPACE_SEPARATOR = "."
+
+    @property
+    @override
+    def NAMESPACE_DEFAULT(self):
+        return {"database": self.schema}
+
+    @override
+    def _init(self, dsn, schema=None, engine_opts=None):
+        self.__exasol = None
+        self.dsn = dsn
+        self.host, self.port = dsn.split(":", 1)
+
+        self.schema = schema
+        self.connection_fields += ("schema",)
+        self.engine_opts = engine_opts or {}
+
+    @override
+    def _connect(self):
+        import pyexasol
+
+        logger.info("Connecting to Exasol ...")
+        self.__exasol = pyexasol.connect(
+            dsn=self.dsn, user=self.username, password=self.password, **self.engine_opts
+        )
+
+    @override
+    def _is_connected(self):
+        return self.__exasol is not None
+
+    @override
+    def _disconnect(self):
+        try:
+            self.__exasol.close()
+        except Exception:
+            pass
+        self.__exasol = None
+        self._schemas = None
+
+    @override
+    def _execute(self, statement, cursor, wait, session_properties, query=True):
+        cursor = self.__exasol
+        if cursor:
+            # NOTE(foxyblue) Implementation of cursor-like behaviour required
+            exa_statement = cursor.export_to_list(statement)
+            return exa_statement
+        else:
+            raise Exception
+        return cursor
+
+    @override
+    def _query_to_table(self, statement, table, if_exists, **kwargs):
+        statements = []
+
+        if if_exists == "fail" and self.table_exists(table):
+            raise RuntimeError("Table {} already exists!".format(table))
+        elif if_exists == "replace":
+            statements.append("SELECT 42;")
+            raise NotImplementedError
+            # NOTE(foxyblue): getting nervous
+            # statements.append("DROP TABLE IF EXISTS {};".format(table))
+        elif if_exists == "append":
+            raise NotImplementedError(
+                "Append operations have not been implemented for {}.".format(
+                    self.__class__.__name__
+                )
+            )
+
+        statement = "CREATE TABLE {table} AS ({statement})".format(
+            table=table, statement=statement
+        )
+        return self.execute(statement, **kwargs)
+
+    @override
+    def _dataframe_to_table(self, df, table, if_exists="fail", **kwargs):
+        table = self._parse_namespaces(table, defaults={"schema": self.username})
+        return _pandas.to_sql(
+            df=df,
+            name=table.table,
+            schema=table.database,
+            con=self.engine,
+            index=False,
+            if_exists=if_exists,
+            **kwargs
+        )
+
+    @override
+    def _table_list(self, namespace, **kwargs):
+        return self.query("SHOW TABLES IN {}".format(namespace), **kwargs)
+
+    @override
+    def _table_exists(self, table, **kwargs):
+        logger.disabled = True
+        try:
+            self.table_desc(table, **kwargs)
+            return True
+        except:
+            return False
+        finally:
+            logger.disabled = False
+
+    @override
+    def _table_drop(self, table, **kwargs):
+        raise NotImplementedError
+        # NOTE(foxyblue): getting nervous
+        # return self.execute("DROP TABLE {table}".format(table=table))
+
+    @override
+    def _table_desc(self, table, **kwargs):
+        return self.query("DESCRIBE {0}".format(table), **kwargs)
+
+    @override
+    def _table_head(self, table, n=10, **kwargs):
+        return self.query("SELECT * FROM {} LIMIT {}".format(table, n), **kwargs)
+
+    @override
+    def _table_props(self, table, **kwargs):
+        raise NotImplementedError

--- a/omniduct/databases/exasol.py
+++ b/omniduct/databases/exasol.py
@@ -31,8 +31,8 @@ class ExasolClient(DatabaseClient):
     NAMESPACE_QUOTECHAR = '"'
     NAMESPACE_SEPARATOR = "."
 
-    @property
     @override
+    @property
     def NAMESPACE_DEFAULT(self):
         return {"schema": self.schema}
 
@@ -116,8 +116,10 @@ class ExasolClient(DatabaseClient):
     def _table_list(self, namespace, **kwargs):
         # Since this namespace is a conditional, exasol requires single quotations
         # instead of double quotations. " -> '
-        namespace = str(namespace).replace('"', "'")
-        query = "SELECT TABLE_NAME FROM EXA_ALL_TABLES WHERE table_schema={}".format(namespace)
+        query = (
+            "SELECT TABLE_NAME FROM EXA_ALL_TABLES WHERE table_schema={}"
+            .format(namespace.render(quote_char="'"))
+        )
         return self.query(query, **kwargs)
 
     @override
@@ -134,20 +136,26 @@ class ExasolClient(DatabaseClient):
     @override
     def _table_drop(self, table, **kwargs):
         # Schema and tables are always under uppercase namespaces.
-        table = str(table).upper()
-        return self.execute("DROP TABLE {table}".format(table=table))
+        return self.execute(
+            "DROP TABLE {table}".format(table=str(table).upper()),
+            **kwargs
+        )
 
     @override
     def _table_desc(self, table, **kwargs):
         # Schema and tables are always under uppercase namespaces.
-        table = str(table).upper()
-        return self.query("DESCRIBE {0}".format(table), **kwargs)
+        return self.query(
+            "DESCRIBE {0}".format(str(table).upper()),
+            **kwargs
+        )
 
     @override
     def _table_head(self, table, n=10, **kwargs):
         # Schema and tables are always under uppercase namespaces.
-        table = str(table).upper()
-        return self.query("SELECT * FROM {} LIMIT {}".format(table, n), **kwargs)
+        return self.query(
+            "SELECT * FROM {} LIMIT {}".format(str(table).upper(), n),
+            **kwargs
+        )
 
     @override
     def _table_props(self, table, **kwargs):

--- a/omniduct/databases/exasol.py
+++ b/omniduct/databases/exasol.py
@@ -50,7 +50,7 @@ class ExasolClient(DatabaseClient):
 
         logger.info("Connecting to Exasol ...")
         self.__exasol = pyexasol.connect(
-            dsn=f"{self.host}:{self.port}",
+            dsn="{host}:{port}".format(host=self.host, port=self.port),
             user=self.username,
             password=self.password,
             **self.engine_opts,

--- a/omniduct/protocols.py
+++ b/omniduct/protocols.py
@@ -6,6 +6,7 @@
 
 from .caches.filesystem import FileSystemCache
 from .databases.druid import DruidClient
+from .databases.exasol import ExasolClient
 from .databases.hiveserver2 import HiveServer2Client
 from .databases.neo4j import Neo4jClient
 from .databases.presto import PrestoClient


### PR DESCRIPTION
I have include an implementation for interfacing the analytical database [Exasol](https://www.exasol.com/en/) into omniducts.

I have used [Pyexasol](https://github.com/badoo/pyexasol/blob/master/pyexasol/connection.py#L217) as the connection library. (This is added as a dependency.)

I based this heavily around the [SQLAlchemyClient](https://github.com/airbnb/omniduct/blob/master/omniduct/databases/sqlalchemy.py#L12).

#### pyexasol cursor

pyexasol.ExaStatement behaves similarly to a DBAPI2 Cursor and I've used a similar work around as found in the `neo4j.py` [client](https://github.com/airbnb/omniduct/blob/master/omniduct/databases/neo4j.py#L56).

>Driver does not use ODBC. Driver does not strictly follow DB-API 2.0 in favor of Exasol-specific features.

- Source: [pyexasol](https://github.com/badoo/pyexasol/blob/master/setup.py#L25)

