### PR TITLE
Method in example does not exist

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -159,8 +159,8 @@ Task 3: Persist service configuration for use in multiple sessions
     ...         remote: my_server
     ... """)
 
-    >>> pc = duct_registry['presto_local']
-    >>> pc.query("SELECT 42")
+    >>> %%presto_local
+    ... SELECT 42
     ...
     # And so on.
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -146,7 +146,7 @@ Task 3: Persist service configuration for use in multiple sessions
 
     # Specify a YAML configuration verbatim (or the filename of a yaml configuration)
     # In this case we create the configuration for the previous task.
-    >>> duct_registry.import_from_config("""
+    >>> duct_registry.register_from_config("""
     ... remotes:
     ...     my_server:
     ...         protocol: ssh
@@ -159,8 +159,8 @@ Task 3: Persist service configuration for use in multiple sessions
     ...         remote: my_server
     ... """)
 
-    >>> %%presto_local
-    ... SELECT 42
+    >>> pc = duct_registry['presto_local']
+    >>> pc.query("SELECT 42")
     ...
     # And so on.
 


### PR DESCRIPTION
It looks like the [method](https://github.com/airbnb/omniduct/compare/master...foxyblue:fix/quick-start-example?expand=1#diff-9d8a6f5b32d4a70a56734fd0eb50dd5bL149) in the docs was [removed and replaced](https://github.com/airbnb/omniduct/commit/0f9f823919f53180fe064922dc4b65f6e9bae3f6#diff-dff26fb1fc0fb47bf9c77cf98bcf73b6L80) with `register_from_config`.

