### PR TITLE
[CI] Add Python 3.7 and 3.8 to test setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: python
 python:
   - "2.7"
   - "3.6"
-  # - "3.7"  # Not currently implemented in tox / travis
+  - "3.7"
+  - "3.8"
 
 before_install:
   - pip install flake8 wheel tox-travis

--- a/omniduct/databases/_schemas.py
+++ b/omniduct/databases/_schemas.py
@@ -72,7 +72,7 @@ class SchemasMixin(object):
             if not getattr(self, '_schemas', None):
                 assert getattr(self, '_sqlalchemy_metadata', None) is not None, (
                     "`{class_name}` instances do not provide the required sqlalchemy metadata "
-                    "for schema exploration.".format(self.__class__.__name__)
+                    "for schema exploration.".format(class_name=self.__class__.__name__)
                 )
                 self._schemas = Schemas(self._sqlalchemy_metadata)
             return self._schemas

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -143,7 +143,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
                 linenumber = message['errorLocation']['lineNumber'] - 1
                 splt = statement.splitlines()
                 splt[linenumber] += '   <--  {errorType} ({errorName}) occurred. {message} '.format(**message)
-                context = '\n\n[Error Context]\n{}\n'.format('\n'.join([splt[l] for l in range(max(linenumber - 1, 0),
+                context = '\n\n[Error Context]\n{}\n'.format('\n'.join([splt[ln] for ln in range(max(linenumber - 1, 0),
                                                                                                min(linenumber + 2, len(splt)))]))
 
                 class ErrContext(object):

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -144,7 +144,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
                 splt = statement.splitlines()
                 splt[linenumber] += '   <--  {errorType} ({errorName}) occurred. {message} '.format(**message)
                 context = '\n\n[Error Context]\n{}\n'.format('\n'.join([splt[ln] for ln in range(max(linenumber - 1, 0),
-                                                                                               min(linenumber + 2, len(splt)))]))
+                                                                                                 min(linenumber + 2, len(splt)))]))
 
                 class ErrContext(object):
 

--- a/omniduct/filesystems/base.py
+++ b/omniduct/filesystems/base.py
@@ -787,9 +787,9 @@ class FileSystemFile(object):
     def mode(self, mode):
         try:
             assert len(set(mode)) == len(mode)
-            assert sum(l in mode for l in ['r', 'w', 'a', '+', 't', 'b']) == len(mode)
-            assert sum(l in mode for l in ['r', 'w', 'a']) == 1
-            assert sum(l in mode for l in ['t', 'b']) < 2
+            assert sum(opt in mode for opt in ['r', 'w', 'a', '+', 't', 'b']) == len(mode)
+            assert sum(opt in mode for opt in ['r', 'w', 'a']) == 1
+            assert sum(opt in mode for opt in ['t', 'b']) < 2
         except AssertionError:
             raise ValueError("invalid mode: '{}'".format(mode))
         self.__mode = mode

--- a/omniduct/utils/ports.py
+++ b/omniduct/utils/ports.py
@@ -77,5 +77,5 @@ def naive_load_balancer(hosts, port):
     raise RuntimeError(
         "Unable to connect to any of the hosts associated with this service. "
         "This may be due to networking issues, such as not being connected to "
-        "the internet or your company's VPN.".format(host)
+        "the internet or your company's VPN."
     )

--- a/omniduct/utils/proxies.py
+++ b/omniduct/utils/proxies.py
@@ -32,7 +32,7 @@ class TreeProxy:
             if not isinstance(self.__tree__[name], TreeProxy):
                 return TreeProxy._for_tree(self.__tree__[name], name=self.__name_of_child(name))
             return self.__tree__[name]
-        raise KeyError('Invalid child node.'.format(name))
+        raise KeyError('Invalid child node `{node_name}`.'.format(node_name=name))
 
     def __iter__(self):
         return iter(self.__tree__)
@@ -44,7 +44,7 @@ class TreeProxy:
         try:
             return self[name]
         except KeyError:
-            raise AttributeError('Invalid child node.'.format(name))
+            raise AttributeError('Invalid child node `{node_name}`.'.format(node_name=name))
 
     def __dir__(self):
         return list(self.__tree__)

--- a/setup.py
+++ b/setup.py
@@ -42,6 +42,7 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 
     # Package details

--- a/tox.ini
+++ b/tox.ini
@@ -2,7 +2,8 @@
 envlist =
     py27
     py36
-    # py37  # Not currently implemented in tox.
+    py37
+    py38
 
 [testenv]
 deps=


### PR DESCRIPTION
We should be including newer Pythons in the CI config.
Should we also look at dropping Python 2 in the near future?