### PR TITLE
Fix webhdfs client init when no autoconf

### DIFF
--- a/omniduct/filesystems/webhdfs.py
+++ b/omniduct/filesystems/webhdfs.py
@@ -56,6 +56,8 @@ class WebHdfsClient(FileSystemClient):
                 return random.choice(duct.namenodes)
 
             self._host = partial(get_host_and_set_namenodes, cluster=auto_conf_cluster, conf_path=auto_conf_path)
+        else:
+            self._host = self.namenodes
 
         self.__webhdfs = None
         self.__webhdfs_kwargs = kwargs


### PR DESCRIPTION
quick fix for :
```
>>> client.connect()
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/opt/test/lib/python3.8/site-packages/interface_meta/utils/inspection.py", line 103, in wrapper
    return function(*args, **kwargs)
  File "/opt/test/lib/python3.8/site-packages/interface_meta/utils/inspection.py", line 103, in wrapper
    return function(*args, **kwargs)
  File "<decorator-gen-1>", line 2, in connect
  File "/opt/test/lib/python3.8/site-packages/omniduct/utils/debug.py", line 275, in logging_scope
    raise_with_traceback(e)
  File "/opt/test/lib/python3.8/site-packages/future/utils/__init__.py", line 446, in raise_with_traceback
    raise exc.with_traceback(traceback)
  File "/opt/test/lib/python3.8/site-packages/omniduct/utils/debug.py", line 271, in logging_scope
    f = func(*args, **kwargs)
  File "/opt/test/lib/python3.8/site-packages/omniduct/duct.py", line 463, in connect
    self.__assert_server_reachable()
  File "/opt/test/lib/python3.8/site-packages/omniduct/duct.py", line 424, in __assert_server_reachable
    raise ValueError("Port specified but no host provided.")
ValueError: Port specified but no host provided.
```