### PR TITLE
Support custom requests session in presto connections

### DIFF
--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -116,7 +116,8 @@ class PrestoClient(DatabaseClient, SchemasMixin):
             cursor = cursor or presto.Cursor(
                 host=self.host, port=self.port, username=self.username, password=self.password,
                 catalog=self.catalog, schema=self.schema, session_props=session_properties,
-                poll_interval=1, source=self.source, protocol=self.server_protocol, requests_session=self.requests_session
+                poll_interval=1, source=self.source, protocol=self.server_protocol,
+                requests_session=self.requests_session
             )
             cursor.execute(statement)
             status = cursor.poll()

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -49,7 +49,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         }
 
     @override
-    def _init(self, catalog='default', schema='default', server_protocol='http', source=None, **connection_options):
+    def _init(self, catalog='default', schema='default', server_protocol='http', source=None, requests_session=None):
         """
         catalog (str): The default catalog to use in database queries.
         schema (str): The default schema/database to use in database queries.
@@ -64,7 +64,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         self.source = source
         self.__presto = None
         self.connection_fields += ('catalog', 'schema')
-        self.connection_options = connection_options
+        self.requests_session = requests_session
 
     @property
     def source(self):
@@ -116,7 +116,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
             cursor = cursor or presto.Cursor(
                 host=self.host, port=self.port, username=self.username, password=self.password,
                 catalog=self.catalog, schema=self.schema, session_props=session_properties,
-                poll_interval=1, source=self.source, protocol=self.server_protocol, **self.connection_options
+                poll_interval=1, source=self.source, protocol=self.server_protocol, requests_session=self.requests_session
             )
             cursor.execute(statement)
             status = cursor.poll()

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -49,7 +49,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         }
 
     @override
-    def _init(self, catalog='default', schema='default', server_protocol='http', source=None):
+    def _init(self, catalog='default', schema='default', server_protocol='http', source=None, **connection_options):
         """
         catalog (str): The default catalog to use in database queries.
         schema (str): The default schema/database to use in database queries.
@@ -64,6 +64,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         self.source = source
         self.__presto = None
         self.connection_fields += ('catalog', 'schema')
+        self.connection_options = connection_options
 
     @property
     def source(self):
@@ -115,7 +116,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
             cursor = cursor or presto.Cursor(
                 host=self.host, port=self.port, username=self.username, password=self.password,
                 catalog=self.catalog, schema=self.schema, session_props=session_properties,
-                poll_interval=1, source=self.source, protocol=self.server_protocol
+                poll_interval=1, source=self.source, protocol=self.server_protocol, **self.connection_options
             )
             cursor.execute(statement)
             status = cursor.poll()

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -57,7 +57,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
             service ('http' or 'https'). (default='http')
         source (str): The source of this query (by default "omniduct <version>").
             If manually specified, result will be: "<source> / omniduct <version>".
-        requests_session (requests.Session): an optional ``requests.Session`` object for advanced usage.
+        requests_session (requests.Session): an optional requests.Session object for advanced usage.
             Passed through to the pyhive Cursor which supports custom requests sessions for advanced usage
             such as custom headers, cookie values, retry logic, etc.
         """
@@ -67,7 +67,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
         self.source = source
         self.__presto = None
         self.connection_fields += ('catalog', 'schema')
-        self.requests_session = requests_session
+        self._requests_session = requests_session
 
     @property
     def source(self):
@@ -120,7 +120,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
                 host=self.host, port=self.port, username=self.username, password=self.password,
                 catalog=self.catalog, schema=self.schema, session_props=session_properties,
                 poll_interval=1, source=self.source, protocol=self.server_protocol,
-                requests_session=self.requests_session
+                requests_session=self._requests_session
             )
             cursor.execute(statement)
             status = cursor.poll()

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -57,6 +57,9 @@ class PrestoClient(DatabaseClient, SchemasMixin):
             service ('http' or 'https'). (default='http')
         source (str): The source of this query (by default "omniduct <version>").
             If manually specified, result will be: "<source> / omniduct <version>".
+        requests_session (requests.Session): an optional ``requests.Session`` object for advanced usage.
+            Passed through to the pyhive Cursor which supports custom requests sessions for advanced usage
+            such as custom headers, cookie values, retry logic, etc.
         """
         self.catalog = catalog
         self.schema = schema


### PR DESCRIPTION
`pyhive` supports passing through a custom requests session for advanced usage such as custom headers, cookie values, retry logic, etc - https://github.com/dropbox/PyHive/blob/master/pyhive/presto.py#L115

This PR adds support for passing through a custom requests session to `pyhive` when creating an `omniduct` `PrestoClient`.