### PR TITLE
Fix mutation and copying of `ParsedNamespaces`.

### DIFF
--- a/omniduct/databases/_namespaces.py
+++ b/omniduct/databases/_namespaces.py
@@ -2,7 +2,7 @@ import re
 from collections import OrderedDict
 
 
-class ParsedNamespaces:
+class ParsedNamespaces(object):
     """
     A namespace parser for DatabaseClient subclasses.
 


### PR DESCRIPTION
`ParsedNamespaces` heretofore could not be copied or mutated (conveniently). This patch fixes this problem by allowing `ParsedNamespaces` to be copied using `copy.copy` and to mutate namespace values directly using `<instance>.<namespace> = <value>`.