### PR TITLE
Fix compatibility with sqlalchemy>=2

### DIFF
--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -122,7 +122,6 @@ class DatabaseClient(Duct, MagicsProvider):
         self._templates = templates or {}
         self._template_context = template_context or {}
         self._sqlalchemy_engine = None
-        self._sqlalchemy_metadata = None
         self._default_format_opts = default_format_opts or {}
 
         self._init(**kwargs)

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -117,7 +117,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
 
     @override
     def _connect(self):
-        from sqlalchemy import create_engine, MetaData
+        from sqlalchemy import create_engine
 
         if self.driver == "pyhive":
             try:
@@ -142,7 +142,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
             self._sqlalchemy_engine = create_engine(
                 f"hive://{self.host}:{self.port}/{self.schema}"
             )
-            self._sqlalchemy_metadata = MetaData(self._sqlalchemy_engine)
         elif self.driver == "impyla":
             try:
                 import impala.dbapi
@@ -165,7 +164,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
             self._sqlalchemy_engine = create_engine(
                 f"impala://{self.host}:{self.port}/{self.schema}"
             )
-            self._sqlalchemy_metadata = MetaData(self._sqlalchemy_engine)
 
     def __hive_cursor(self):
         if (
@@ -192,7 +190,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         # pylint: disable-next=attribute-defined-outside-init
         self.__hive = None
         self._sqlalchemy_engine = None
-        self._sqlalchemy_metadata = None
         # pylint: disable-next=attribute-defined-outside-init
         self._schemas = None
 

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -90,14 +90,13 @@ class PrestoClient(DatabaseClient, SchemasMixin):
 
     @override
     def _connect(self):
-        from sqlalchemy import create_engine, MetaData
+        from sqlalchemy import create_engine
 
         logging.getLogger("pyhive").setLevel(1000)  # Silence pyhive logging.
         logger.info("Connecting to Presto coordinator...")
         self._sqlalchemy_engine = create_engine(
             f"presto://{self.host}:{self.port}/{self.catalog}/{self.schema}"
         )
-        self._sqlalchemy_metadata = MetaData(self._sqlalchemy_engine)
 
     @override
     def _is_connected(self):
@@ -107,7 +106,6 @@ class PrestoClient(DatabaseClient, SchemasMixin):
     def _disconnect(self):
         logger.info("Disconnecting from Presto coordinator...")
         self._sqlalchemy_engine = None
-        self._sqlalchemy_metadata = None
         self._schemas = None  # pylint: disable=attribute-defined-outside-init
 
     # Querying

--- a/omniduct/databases/sqlalchemy.py
+++ b/omniduct/databases/sqlalchemy.py
@@ -70,6 +70,13 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
             database=self.database,
         )
 
+    @property
+    def _sqlalchemy_engine(self):
+        """
+        The SQLAlchemy engine object for the SchemasMixin.
+        """
+        return self.engine
+
     @override
     def _connect(self):
         import sqlalchemy
@@ -85,7 +92,6 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
 
         # pylint: disable-next=attribute-defined-outside-init
         self.engine = sqlalchemy.create_engine(self.db_uri, **self.engine_opts)
-        self._sqlalchemy_metadata = sqlalchemy.MetaData(self.engine)
 
     @override
     def _is_connected(self):
@@ -95,7 +101,6 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
     def _disconnect(self):
         # pylint: disable-next=attribute-defined-outside-init
         self.engine = None
-        self._sqlalchemy_metadata = None
         # pylint: disable-next=attribute-defined-outside-init
         self._schemas = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ name = "omniduct"
 dynamic = ["version"]
 description = "A toolkit providing a uniform interface for connecting to and extracting data from a wide variety of (potentially remote) data stores (including HDFS, Hive, Presto, MySQL, etc)."
 readme = "README.md"
-license = ""
+license = "MIT"
 authors = [
     { name = "Matthew Wardrop", email = "mpwardrop@gmail.com" },
     { name = "Dan Frank", email = "danfrankj@gmail.com" },


### PR DESCRIPTION
The `MetaData` API changed, and in retrospect, it was never necessary for Omniduct usage to use that object rather than directly using the engine reference.