### PR TITLE
Remove vestigial lint comments and related cleanups.

### DIFF
--- a/omniduct/__init__.py
+++ b/omniduct/__init__.py
@@ -1,16 +1,29 @@
-# flake8: noqa
-
 from omniduct.duct import Duct
 from omniduct.registry import DuctRegistry
 from omniduct.utils.config import config
 from omniduct.utils.debug import logger
 
 from . import protocols
-from ._version import __author__, __author_email__, __version__, __logo__, __docs_url__
+from ._version import __author__, __author_email__, __docs_url__, __logo__, __version__
+
+__all__ = [
+    "Duct",
+    "DuctRegistry",
+    "config",
+    "logger",
+    "protocols",
+    "about",
+    "__author__",
+    "__author_email__",
+    "__docs_url__",
+    "__logo__",
+    "__version__",
+]
 
 
 def about():
     from collections import OrderedDict
+
     from .utils.about import show_about
 
     return show_about(

--- a/omniduct/caches/base.py
+++ b/omniduct/caches/base.py
@@ -87,7 +87,7 @@ def cached_method(
         if _cache.has_key(_key, namespace=_namespace) and not _renew:  # noqa  # has_key is not of a dictionary here
             try:
                 return _cache.get(_key, namespace=_namespace, serializer=_serializer)
-            except Exception as e:  # pylint: disable=broad-exception-caught
+            except Exception as e:
                 logger.warning(
                     "Failed to retrieve results from cache [%s]. Renewing the cache...",
                     e,
@@ -114,7 +114,7 @@ def cached_method(
             # Return from cache every time, just in case serialization operation was
             # destructive (e.g. reading from cursors)
             return _cache.get(_key, namespace=_namespace, serializer=_serializer)
-        except:  # pylint: disable=bare-except
+        except:
             logger.warning(
                 "Failed to save results to cache. If needed, please save them manually."
             )
@@ -133,7 +133,7 @@ class Cache(Duct):
     DUCT_TYPE = Duct.Type.CACHE
 
     @inherit_docs("_init", mro=True)
-    def __init__(self, **kwargs):  # pylint: disable=super-init-not-called
+    def __init__(self, **kwargs):
         Duct.__init_with_kwargs__(self, kwargs)
         self._init(**kwargs)
 
@@ -169,7 +169,7 @@ class Cache(Duct):
             ) as fh:
                 serializer.serialize(value, fh)
             self.set_metadata(key, metadata, namespace=namespace, replace=True)
-        except:  # pylint: disable=bare-except
+        except:
             self.unset(key, namespace=namespace)
             raise
 
@@ -276,7 +276,7 @@ class Cache(Duct):
                 namespace, key, "metadata", mode="r", create=False
             ) as fh:
                 return yaml.safe_load(fh)
-        except:  # pylint: disable=bare-except
+        except:
             return {}
 
     @require_connection

--- a/omniduct/caches/filesystem.py
+++ b/omniduct/caches/filesystem.py
@@ -15,7 +15,7 @@ class FileSystemCache(Cache):
     PROTOCOLS = ["filesystem_cache"]
 
     @override
-    def _init(self, path, fs=None):  # pylint: disable=arguments-differ
+    def _init(self, path, fs=None):
         """
         path (str): The top-level path of the cache in the filesystem.
         fs (FileSystemClient, str): The filesystem client to use as the
@@ -37,7 +37,7 @@ class FileSystemCache(Cache):
 
         if self.registry is not None:
             if isinstance(self.fs, str):
-                self.fs = self.registry.lookup(  # pylint: disable=attribute-defined-outside-init
+                self.fs = self.registry.lookup(
                     self.fs, kind=FileSystemCache.Type.FILESYSTEM
                 )
         if not isinstance(self.fs, FileSystemClient):

--- a/omniduct/databases/_cursor_formatters.py
+++ b/omniduct/databases/_cursor_formatters.py
@@ -129,7 +129,7 @@ class PandasCursorFormatter(CursorFormatter):
         if self.date_fields is not None:
             try:
                 df = pd.io.sql._parse_date_columns(df, self.date_fields)
-            except Exception as e:  # pylint: disable=broad-exception-caught
+            except Exception as e:
                 logger.warning(
                     f"Unable to parse date columns. Perhaps your version of pandas is outdated.Original error message was: {e.__class__.__name__}: {str(e)}"
                 )
@@ -238,7 +238,7 @@ class HiveCursorFormatter(CsvCursorFormatter):
         "quoting": csv.QUOTE_NONE,
     }
 
-    def _init(self):  # pylint: disable=arguments-differ
+    def _init(self):
         CsvCursorFormatter._init(self, include_header=False)
 
     # Convert null values to '\N'.

--- a/omniduct/databases/_schemas.py
+++ b/omniduct/databases/_schemas.py
@@ -1,6 +1,3 @@
-# pylint: disable=abstract-method
-
-
 import pandas as pd
 import sqlalchemy
 from sqlalchemy import Table

--- a/omniduct/databases/base.py
+++ b/omniduct/databases/base.py
@@ -95,7 +95,6 @@ class DatabaseClient(Duct, MagicsProvider):
         return self.NAMESPACE_DEFAULTS_READ
 
     @inherit_docs("_init", mro=True)
-    # pylint: disable-next=super-init-not-called
     def __init__(
         self,
         session_properties=None,
@@ -339,7 +338,6 @@ class DatabaseClient(Duct, MagicsProvider):
 
     @logging_scope("Query", timed=True)
     @render_statement
-    # pylint: disable-next=redefined-builtin
     def query(self, statement, format=None, format_opts=None, use_cache=True, **kwargs):
         """
         Execute a statement against this database and collect formatted data.
@@ -373,7 +371,6 @@ class DatabaseClient(Duct, MagicsProvider):
         formatter = self._get_formatter(format, cursor, **format_opts)
         return formatter.dump()
 
-    # pylint: disable-next=redefined-builtin
     def stream(self, statement, format=None, format_opts=None, batch=None, **kwargs):
         """
         Execute a statement against this database and stream formatted results.
@@ -419,7 +416,6 @@ class DatabaseClient(Duct, MagicsProvider):
         )
         return formatter(cursor, **format_opts)
 
-    # pylint: disable-next=redefined-builtin
     def stream_to_file(self, statement, file, format="csv", fs=None, **kwargs):
         """
         Execute a statement against this database and stream results to a file.
@@ -1008,7 +1004,6 @@ class DatabaseClient(Duct, MagicsProvider):
             if variable is None:
                 return result
 
-            # pylint: disable=redefined-builtin
             format = kwargs.get("format", self.DEFAULT_CURSOR_FORMATTER)
             if show == "head":
                 show = 10

--- a/omniduct/databases/druid.py
+++ b/omniduct/databases/druid.py
@@ -23,10 +23,10 @@ class DruidClient(DatabaseClient):
     # Connection
     @override
     def _connect(self):
-        from pydruid.db import connect  # pylint: disable=import-error
+        from pydruid.db import connect
 
         logger.info("Connecting to Druid database ...")
-        self.__druid = connect(  # pylint: disable=attribute-defined-outside-init
+        self.__druid = connect(
             self.host, self.port, path="/druid/v2/sql/", scheme="http"
         )
         if self.username or self.password:
@@ -44,9 +44,9 @@ class DruidClient(DatabaseClient):
         logger.info("Disconnecting from Druid database ...")
         try:
             self.__druid.close()
-        except:  # pylint: disable=bare-except
+        except:
             pass
-        self.__druid = None  # pylint: disable=attribute-defined-outside-init
+        self.__druid = None
 
     # Querying
     @override
@@ -66,7 +66,7 @@ class DruidClient(DatabaseClient):
         try:
             self.table_desc(table, **kwargs)
             return True
-        except:  # pylint: disable=bare-except
+        except:
             return False
         finally:
             logger.disabled = False

--- a/omniduct/databases/exasol.py
+++ b/omniduct/databases/exasol.py
@@ -47,7 +47,6 @@ class ExasolClient(DatabaseClient):
         import pyexasol
 
         logger.info("Connecting to Exasol ...")
-        # pylint: disable-next=attribute-defined-outside-init
         self.__exasol = pyexasol.connect(
             dsn=f"{self.host}:{self.port}",
             user=self.username,
@@ -63,9 +62,8 @@ class ExasolClient(DatabaseClient):
     def _disconnect(self):
         try:
             self.__exasol.close()
-        except:  # pylint: disable=bare-except
+        except:
             pass
-        # pylint: disable-next=attribute-defined-outside-init
         self.__exasol = None
 
     @override
@@ -122,7 +120,7 @@ class ExasolClient(DatabaseClient):
         try:
             self.table_desc(table, **kwargs)
             return True
-        except:  # pylint: disable=bare-except
+        except:
             return False
         finally:
             logger.disabled = False

--- a/omniduct/databases/hiveserver2.py
+++ b/omniduct/databases/hiveserver2.py
@@ -1,6 +1,3 @@
-# pylint: disable=abstract-method,consider-using-f-string
-
-
 import json
 import os
 import re
@@ -127,7 +124,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
                     "is not installed. Please either install the pyhive package, "
                     "or reconfigure this Duct to use the 'impyla' driver."
                 ) from e
-            # pylint: disable-next=attribute-defined-outside-init
             self.__hive = pyhive.hive.connect(
                 host=None if self._thrift_transport else self.host,
                 port=None if self._thrift_transport else self.port,
@@ -150,7 +146,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
                     "is not installed. Please either install the impyla package, "
                     "or reconfigure this Duct to use the 'pyhive' driver."
                 ) from e
-            # pylint: disable-next=attribute-defined-outside-init
             self.__hive = impala.dbapi.connect(
                 host=self.host,
                 port=self.port,
@@ -171,7 +166,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
             try:
                 with Timeout(1):
                     return self.__hive.cursor()
-            except:  # pylint: disable=bare-except
+            except:
                 self._connect()
         return self.__hive.cursor()
 
@@ -184,12 +179,10 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         logger.info("Disconnecting from Hive coordinator...")
         try:
             self.__hive.close()
-        except:  # pylint: disable=bare-except
+        except:
             pass
-        # pylint: disable-next=attribute-defined-outside-init
         self.__hive = None
         self._sqlalchemy_engine = None
-        # pylint: disable-next=attribute-defined-outside-init
         self._schemas = None
 
     @override
@@ -457,7 +450,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
         try:
             self.table_desc(table, **kwargs)
             return True
-        except:  # pylint: disable=bare-except
+        except:
             return False
         finally:
             logger.disabled = False
@@ -564,7 +557,7 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
 
         # Sanitise column names and map numpy/pandas data-types to hive types.
         columns = []
-        for col, dtype in df.dtypes.iteritems():
+        for col, dtype in df.dtypes.items():
             col_sanitized = re.sub(r"\W", "", col.lower().replace(" ", "_"))
             hive_type = dtype_overrides.get(col) or DTYPE_KIND_HIVE_TYPE.get(dtype.kind)
             if hive_type is None:
@@ -576,7 +569,6 @@ class HiveServer2Client(DatabaseClient, SchemasMixin):
                 )
             columns.append(f"  {col_sanitized}  {hive_type}")
 
-        # pylint: disable-next=possibly-unused-variable
         partition_columns = [f"{col} STRING" for col in partition_cols]
 
         tblprops = [f"'{key}' = '{value}'" for key, value in table_props.items()]

--- a/omniduct/databases/neo4j.py
+++ b/omniduct/databases/neo4j.py
@@ -1,6 +1,3 @@
-# pylint: disable=abstract-method
-
-
 from interface_meta import override
 
 from omniduct.utils.debug import logger
@@ -34,7 +31,6 @@ class Neo4jClient(DatabaseClient):
 
         logger.info("Connecting to Neo4J graph database ...")
         auth = (self.username, self.password) if self.username else None
-        # pylint: disable-next=attribute-defined-outside-init
         self.__driver = GraphDatabase.driver(
             f"bolt://{self.host}:{self.port}", auth=auth
         )  # TODO: Add kerberos support
@@ -48,9 +44,9 @@ class Neo4jClient(DatabaseClient):
         logger.info("Disconnecting from Neo4J graph database ...")
         try:
             self.__driver.close()
-        except:  # pylint: disable=bare-except
+        except:
             pass
-        self.__driver = None  # pylint: disable=attribute-defined-outside-init
+        self.__driver = None
 
     # Querying
     @override

--- a/omniduct/databases/presto.py
+++ b/omniduct/databases/presto.py
@@ -1,6 +1,3 @@
-# pylint: disable=consider-using-f-string
-
-
 import ast
 import logging
 import re
@@ -105,7 +102,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
     def _disconnect(self):
         logger.info("Disconnecting from Presto coordinator...")
         self._sqlalchemy_engine = None
-        self._schemas = None  # pylint: disable=attribute-defined-outside-init
+        self._schemas = None
 
     # Querying
     @override
@@ -176,7 +173,7 @@ class PrestoClient(DatabaseClient, SchemasMixin):
                 )
 
                 logger.error(context)
-            except:  # pylint: disable=bare-except
+            except:
                 logger.warn(
                     "Omniduct was unable to parse the database error messages. Refer to the "
                     "traceback below for full error details."

--- a/omniduct/databases/pyspark.py
+++ b/omniduct/databases/pyspark.py
@@ -1,5 +1,3 @@
-# pylint: disable=abstract-method
-
 from interface_meta import override
 
 from omniduct.databases.base import DatabaseClient
@@ -55,7 +53,6 @@ class PySparkClient(DatabaseClient):
             for key, value in self.config.items():
                 builder.config(key, value)
 
-        # pylint: disable-next=attribute-defined-outside-init
         self._spark_session = builder.getOrCreate()
 
     @override

--- a/omniduct/databases/sqlalchemy.py
+++ b/omniduct/databases/sqlalchemy.py
@@ -61,7 +61,6 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
 
     @property
     def db_uri(self):
-        # pylint: disable-next=consider-using-f-string
         return "{dialect}://{login}@{host_port}/{database}".format(
             dialect=self.dialect + (f"+{self.driver}" if self.driver else ""),
             login=self.username
@@ -94,9 +93,7 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
                 "not supporting ANSI SQL."
             )
 
-        # pylint: disable-next=attribute-defined-outside-init
         self.engine = sqlalchemy.create_engine(self.db_uri, **self.engine_opts)
-        # pylint: disable-next=attribute-defined-outside-init
         self.connection = self.engine.connect()
 
     @override
@@ -107,11 +104,8 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
     def _disconnect(self):
         if self.connection is not None:
             self.connection.close()
-        # pylint: disable-next=attribute-defined-outside-init
         self.connection = None
-        # pylint: disable-next=attribute-defined-outside-init
         self.engine = None
-        # pylint: disable-next=attribute-defined-outside-init
         self._schemas = None
 
     @override
@@ -171,7 +165,7 @@ class SQLAlchemyClient(DatabaseClient, SchemasMixin):
         try:
             self.table_desc(table, **kwargs)
             return True
-        except:  # pylint: disable=bare-except
+        except:
             return False
         finally:
             logger.disabled = False

--- a/omniduct/duct.py
+++ b/omniduct/duct.py
@@ -146,9 +146,9 @@ class Duct(metaclass=InterfaceMeta):
 
         atexit.register(self.disconnect)
         self.__prepared = False
-        self.__getting = False  # pylint: disable=unused-private-member
+        self.__getting = False
         self.__connected = False
-        self.__disconnecting = False  # pylint: disable=unused-private-member
+        self.__disconnecting = False
         self.__cached_auth = {}
         self.__prepreparation_values = {}
 
@@ -198,7 +198,7 @@ class Duct(metaclass=InterfaceMeta):
         return functools.partial(cls._protocols[protocol], protocol=protocol)
 
     @property
-    def __prepare_triggers(self):  # pylint: disable=unused-private-member
+    def __prepare_triggers(self):
         return ("cache",) + object.__getattribute__(self, "connection_fields")
 
     @classmethod
@@ -238,7 +238,7 @@ class Duct(metaclass=InterfaceMeta):
                 object.__setattr__(self, "_Duct__getting", False)
         except AttributeError:
             pass
-        except:  # pylint: disable=bare-except
+        except:
             object.__setattr__(self, "_Duct__getting", False)
             raise
         return object.__getattribute__(self, key)
@@ -498,7 +498,7 @@ class Duct(metaclass=InterfaceMeta):
         if not self.is_connected():
             try:
                 self._connect()
-            except:  # pylint: disable=bare-except
+            except:
                 self.reset()
                 raise
         self.__connected = True
@@ -558,7 +558,7 @@ class Duct(metaclass=InterfaceMeta):
         """
         if not self.__prepared:
             return None
-        self.__disconnecting = True  # pylint: disable=unused-private-member
+        self.__disconnecting = True
         self.__connected = False
 
         try:
@@ -568,7 +568,7 @@ class Duct(metaclass=InterfaceMeta):
                 logger.info(f"Freeing up local port {self.port}...")
                 self.remote.port_forward_stop(local_port=self.port)
         finally:
-            self.__disconnecting = False  # pylint: disable=unused-private-member
+            self.__disconnecting = False
 
         return self
 

--- a/omniduct/filesystems/_webhdfs_helpers.py
+++ b/omniduct/filesystems/_webhdfs_helpers.py
@@ -138,7 +138,6 @@ class CdhHdfsConfParser:
     @property
     def config(self):
         if not hasattr(self, "_config"):
-            # pylint: disable-next=attribute-defined-outside-init
             self._config = self._get_config()
         return self._config
 

--- a/omniduct/filesystems/base.py
+++ b/omniduct/filesystems/base.py
@@ -24,7 +24,7 @@ class FileSystemClient(Duct, MagicsProvider):
     DEFAULT_PORT = None
 
     @inherit_docs("_init", mro=True)
-    def __init__(  # pylint: disable=super-init-not-called
+    def __init__(
         self, cwd=None, home=None, read_only=False, global_writes=False, **kwargs
     ):
         """
@@ -862,7 +862,7 @@ class FileSystemFile:
     def __enter__(self):
         return self
 
-    def __exit__(self, type, value, tb):  # pylint: disable=redefined-builtin
+    def __exit__(self, type, value, tb):
         self.close()
 
     def close(self):
@@ -977,8 +977,8 @@ class FileSystemFileDesc(
         fs,
         path,
         name,
-        type,  # pylint: disable=redefined-builtin
-        bytes=None,  # pylint: disable=redefined-builtin
+        type,
+        bytes=None,
         owner=None,
         group=None,
         permissions=None,

--- a/omniduct/filesystems/local.py
+++ b/omniduct/filesystems/local.py
@@ -1,5 +1,3 @@
-# pylint: disable=abstract-method # We export a different type of file-handle.
-
 import builtins
 import datetime
 import errno

--- a/omniduct/filesystems/s3.py
+++ b/omniduct/filesystems/s3.py
@@ -1,4 +1,3 @@
-# pylint: disable=attribute-defined-outside-init
 import logging
 
 from interface_meta import override
@@ -159,7 +158,7 @@ class S3Client(FileSystemClient):
         try:
             self._client.get_object(Bucket=self.bucket, Key=self._s3_path(path) or "")
             return True
-        except:  # pylint: disable=bare-except
+        except:
             return False
 
     # Directory handling and enumeration

--- a/omniduct/filesystems/webhdfs.py
+++ b/omniduct/filesystems/webhdfs.py
@@ -76,7 +76,6 @@ class WebHdfsClient(FileSystemClient):
     def _connect(self):
         from ._webhdfs_helpers import OmniductPyWebHdfsClient
 
-        # pylint: disable-next=attribute-defined-outside-init
         self.__webhdfs = OmniductPyWebHdfsClient(
             host=self._host,
             port=self._port,
@@ -92,12 +91,11 @@ class WebHdfsClient(FileSystemClient):
             if self.remote and not self.remote.is_connected():
                 return False
             return self.__webhdfs is not None
-        except:  # pylint: disable=bare-except
+        except:
             return False
 
     @override
     def _disconnect(self):
-        # pylint: disable-next=attribute-defined-outside-init
         self.__webhdfs = None
 
     # Path properties and helpers

--- a/omniduct/remotes/base.py
+++ b/omniduct/remotes/base.py
@@ -121,7 +121,7 @@ class RemoteClient(FileSystemClient):
     DEFAULT_PORT = None
 
     @inherit_docs("_init", mro=True)
-    def __init__(self, smartcards=None, **kwargs):  # pylint: disable=super-init-not-called
+    def __init__(self, smartcards=None, **kwargs):
         """
         Args:
             smartcards (dict): Mapping of smartcard names to system libraries

--- a/omniduct/remotes/ssh.py
+++ b/omniduct/remotes/ssh.py
@@ -457,7 +457,6 @@ class SSHClient(RemoteClient):
         if fs is None or isinstance(fs, LocalFsClient):
             logger.info("Copying file to local...")
             dest = dest or posixpath.basename(source)
-            # pylint: disable-next=consider-using-f-string
             cmd = "scp -r -o ControlPath={socket} {login}:'{remote_file}' '{local_file}'".format(
                 socket=self._socket_path,
                 login=self._login_info,
@@ -467,7 +466,7 @@ class SSHClient(RemoteClient):
             proc = run_in_subprocess(cmd, check_output=True)
             logger.info(proc.stderr or "Success")
         else:
-            super(RemoteClient, self).download(source, dest, overwrite, fs)
+            super().download(source, dest, overwrite, fs)
 
     @override
     @require_connection
@@ -506,7 +505,6 @@ class SSHClient(RemoteClient):
         if fs is None or isinstance(fs, LocalFsClient):
             logger.info("Copying file from local...")
             dest = dest or posixpath.basename(source)
-            # pylint: disable-next=consider-using-f-string
             cmd = "scp -r -o ControlPath={socket} '{local_file}' {login}:'{remote_file}'".format(
                 socket=self._socket_path,
                 local_file=source.replace('"', r"\""),  # quote escaped for bash
@@ -516,7 +514,7 @@ class SSHClient(RemoteClient):
             proc = run_in_subprocess(cmd, check_output=True)
             logger.info(proc.stderr or "Success")
         else:
-            super(RemoteClient, self).upload(source, dest, overwrite, fs)
+            super().upload(source, dest, overwrite, fs)
 
     # Helper methods
 

--- a/omniduct/remotes/ssh_paramiko.py
+++ b/omniduct/remotes/ssh_paramiko.py
@@ -1,5 +1,3 @@
-# pylint: disable=abstract-method
-
 import posixpath
 import select
 import socketserver
@@ -39,14 +37,12 @@ class ParamikoSSHClient(RemoteClient):
     def _connect(self):
         import paramiko
 
-        # pylint: disable-next=attribute-defined-outside-init
         self.__client = paramiko.SSHClient()
         self.__client.set_missing_host_key_policy(paramiko.client.AutoAddPolicy())
         self.__client.load_system_host_keys()
 
         try:
             self.__client.connect(self.host, username=self.username)
-            # pylint: disable-next=attribute-defined-outside-init
             self.__client_sftp = paramiko.SFTPClient.from_transport(
                 self.__client.get_transport()
             )
@@ -59,7 +55,7 @@ class ParamikoSSHClient(RemoteClient):
     def _is_connected(self):
         try:
             return self.__client.get_transport().is_active()
-        except:  # pylint: disable=bare-except
+        except:
             return False
 
     @override
@@ -67,7 +63,7 @@ class ParamikoSSHClient(RemoteClient):
         try:
             self.__client_sftp.close()
             self.__client.close()
-        except:  # pylint: disable=bare-except
+        except:
             pass
 
     @override
@@ -199,7 +195,7 @@ class Handler(socketserver.BaseRequestHandler):
                 (self.chain_host, self.chain_port),
                 self.request.getpeername(),
             )
-        except Exception as e:  # pylint: disable=broad-exception-caught
+        except Exception as e:
             logger.info(
                 "Incoming request to %s:%d failed: %s",
                 self.chain_host,

--- a/omniduct/restful/base.py
+++ b/omniduct/restful/base.py
@@ -30,7 +30,7 @@ class RestClientBase(Duct):
     DUCT_TYPE = Duct.Type.RESTFUL
 
     @inherit_docs("_init", mro=True)
-    def __init__(  # pylint: disable=super-init-not-called
+    def __init__(
         self,
         server_protocol="http",
         assume_json=False,
@@ -120,7 +120,7 @@ class RestClientBase(Duct):
                 raise RuntimeError(
                     f"Server responded with HTTP response code {request.status_code}, with content: {json.dumps(request.json())}."
                 )
-            except Exception as e:  # pylint: disable=broad-exception-caught
+            except Exception as e:
                 raise RuntimeError(
                     f"Server responded with HTTP response code {request.status_code}, with content: {request.content.decode('utf-8')}."
                 ) from e

--- a/omniduct/utils/about.py
+++ b/omniduct/utils/about.py
@@ -114,7 +114,7 @@ def show_about(
         ip = get_ipython()
         if ip is not None and ip.has_trait("kernel"):
             return display(HTML(jinja2.Template(ABOUT_TEMPLATE_HTML).render(**context)))
-    except:  # pylint: disable=bare-except
+    except:
         pass
 
     # Textual fallback if HTML not running in a notebook

--- a/omniduct/utils/config.py
+++ b/omniduct/utils/config.py
@@ -26,7 +26,7 @@ class ConfigurationRegistry:
         default=None,
         onchange=None,
         onload=None,
-        type=None,  # pylint: disable=redefined-builtin
+        type=None,
         host=None,
     ):
         """
@@ -61,7 +61,7 @@ class ConfigurationRegistry:
         try:
             caller_frame = inspect.currentframe().f_back
             host = inspect.getmodule(caller_frame).__name__
-        except:  # pylint: disable=bare-except
+        except:
             host = "unknown"
 
         if default is not None and type is not None and not isinstance(default, type):
@@ -138,7 +138,7 @@ class Configuration(ConfigurationRegistry):
             # Restore configuration
             try:
                 self.load(force=True)
-            except Exception as e:  # pylint: disable=broad-exception-caught
+            except Exception as e:
                 raise RuntimeError(
                     f"Configuration file at {self.__config_path} cannot be loaded. Perhaps try deleting it."
                 ) from e

--- a/omniduct/utils/debug.py
+++ b/omniduct/utils/debug.py
@@ -174,7 +174,7 @@ class StatusLogger:
             try:
                 caller = inspect.stack()[2]
                 context = inspect.getmodule(caller.frame).__name__
-            except:  # pylint: disable=bare-except
+            except:
                 context = "omniduct"
         if context != "omniduct" and not context.startswith("omniduct."):
             context = f"omniduct.external.{context}"
@@ -228,7 +228,6 @@ def detect_scopes():
     return out_scopes
 
 
-# pylint: disable-next=abstract-method
 class LoggingHandler(logging.Handler):
     """
     An implementation of Logging.Handler to render the logging methods shown in Omniduct and derivatives.
@@ -248,7 +247,7 @@ class LoggingHandler(logging.Handler):
     def handle(self, record):
         try:
             scopes = logger.current_scopes
-        except:  # pylint: disable=bare-except
+        except:
             scopes = []
 
         if config.logging_level < logging.INFO:  # Print everything verbosely
@@ -304,7 +303,7 @@ def logging_scope(name, *wargs, **wkwargs):
         try:
             f = func(*args, **kwargs)
             return f
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception:
             success = False
             raise
         finally:

--- a/omniduct/utils/decorators.py
+++ b/omniduct/utils/decorators.py
@@ -21,7 +21,7 @@ def require_connection(f, self, *args, **kwargs):
 
     try:
         return f(self, *args, **kwargs)
-    except Exception:  # pylint: disable=broad-exception-caught
+    except Exception:
         # Check to see if it is possible that we failed due to connection issues.
         # If so, try again once more. If we fail again, raise.
         # TODO: Explore adding a DuctConnectionError class and filter this

--- a/omniduct/utils/magics.py
+++ b/omniduct/utils/magics.py
@@ -62,7 +62,7 @@ class MagicsProvider(metaclass=ABCMeta):
             if ip is None:
                 raise RuntimeError("IPython kernel is not running.")
             has_ipython = True
-        except Exception:  # pylint: disable=broad-exception-caught
+        except Exception:
             has_ipython = False
 
         if has_ipython:

--- a/omniduct/utils/ports.py
+++ b/omniduct/utils/ports.py
@@ -52,7 +52,7 @@ def is_port_bound(hostname, port, timeout=None):
         s.settimeout(timeout)
     try:
         s.connect((hostname, port))
-    except:  # pylint: disable=bare-except
+    except:
         return False
     finally:
         s.close()

--- a/omniduct/utils/processes.py
+++ b/omniduct/utils/processes.py
@@ -83,6 +83,5 @@ class Timeout:
         signal.signal(signal.SIGALRM, self.handle_timeout)
         signal.alarm(self.seconds)
 
-    # pylint: disable-next=redefined-builtin
     def __exit__(self, type, value, traceback):
         signal.alarm(0)


### PR DESCRIPTION
This patch removes some vestigial linting comments targeting `flake8` and `pylint`, which then prompted a few more lint-related code changes.